### PR TITLE
fix: Error importing plugin "pydantic.mypy": cannot import name 'Type…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,8 @@ install_requires =
     dataclasses-avroschema~=0.25.2
     dataclasses~=0.8; python_version == '3.6'
     fastavro~=1.4.7
-    pydantic~=1.8.2
+    # https://github.com/pydantic/pydantic/issues/3528
+    pydantic>=1.8.2
 
 [options.packages.find]
 exclude=tests


### PR DESCRIPTION
fix: Error importing plugin "pydantic.mypy": cannot import name 'TypeVarDef' from 'mypy.types'
