### PR TITLE
#56: update code style to 3.9

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,6 +42,10 @@ jobs:
           pip install -U mypy==1.10.0
       - name: run mypy
         run: mypy --config setup.cfg .
+      - name: Install ruff
+        run: pip install ruff
+      - name: Ruff check
+        run: ruff check .
   checks:
     needs: [independent]
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,10 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+target-version="py39"
+exclude = [
+	"wunderkafka/config/generated/*",
+	"examples/*"
+]

--- a/tests/integration/cloudera/test_deserializing.py
+++ b/tests/integration/cloudera/test_deserializing.py
@@ -13,9 +13,9 @@ from wunderkafka.consumers.constructor import HighLevelDeserializingConsumer
 
 
 @dataclass
-class Msg(object):
+class Msg:
     payload: bytes
-    deserialized: Dict[str, Any]
+    deserialized: dict[str, Any]
 
     def serialized(self, header: bytes) -> bytes:
         return header + self.payload
@@ -51,7 +51,7 @@ def test_consume_moving_parts(sr_root: Path, topic: str, header: bytes) -> None:
 
     consumer.subscribe([topic], from_beginning=True)
 
-    msgs: List[Message] = consumer.consume()
+    msgs: list[Message] = consumer.consume()
     [message] = msgs
     assert message.key() is None
     assert message.value() == SIGNAL_MESSAGE.deserialized

--- a/tests/integration/cloudera/test_deserializing.py
+++ b/tests/integration/cloudera/test_deserializing.py
@@ -1,12 +1,12 @@
-from typing import Any, Dict, List
+from typing import Any
 from pathlib import Path
 from dataclasses import dataclass
 
 import pytest
 
-from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.tests import TestConsumer, TestHTTPClient
 from wunderkafka.serdes.avro import FastAvroDeserializer
+from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.tests.consumer import Message
 from wunderkafka.schema_registry import SimpleCache, ClouderaSRClient
 from wunderkafka.consumers.constructor import HighLevelDeserializingConsumer

--- a/tests/integration/cloudera/test_serializing_avromodel.py
+++ b/tests/integration/cloudera/test_serializing_avromodel.py
@@ -3,11 +3,11 @@ from pathlib import Path
 import pytest
 from pydantic import Field, BaseModel
 
-from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.time import now
 from wunderkafka.tests import TestProducer, TestHTTPClient
 from wunderkafka.serdes.avro import AvroModelSerializer
 from wunderkafka.serdes.store import AvroModelRepo
+from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.schema_registry import SimpleCache, ClouderaSRClient
 from wunderkafka.producers.constructor import HighLevelSerializingProducer
 

--- a/tests/integration/confluent/avro/test_avro_deserializing.py
+++ b/tests/integration/confluent/avro/test_avro_deserializing.py
@@ -42,7 +42,7 @@ def test_consume_moving_parts(sr_root_existing: Path, topic: str, header: bytes)
 
     consumer.subscribe([topic], from_beginning=True)
 
-    events: List[StreamResult] = consumer.consume()
+    events: list[StreamResult] = consumer.consume()
     [event] = events
 
     assert event.payload == SIGNAL_MESSAGE.deserialized

--- a/tests/integration/confluent/avro/test_avro_deserializing.py
+++ b/tests/integration/confluent/avro/test_avro_deserializing.py
@@ -1,17 +1,15 @@
-from typing import List
 from pathlib import Path
 
 import pytest
 
-from tests.integration.confluent.conftest import Msg
-from wunderkafka.consumers.types import StreamResult
-from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.tests import TestConsumer, TestHTTPClient
 from wunderkafka.serdes.avro import FastAvroDeserializer
+from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.tests.consumer import Message
+from wunderkafka.consumers.types import StreamResult
 from wunderkafka.schema_registry import SimpleCache, ConfluentSRClient
 from wunderkafka.consumers.constructor import HighLevelDeserializingConsumer
-
+from tests.integration.confluent.conftest import Msg
 
 SIGNAL_MESSAGE = Msg(
     payload=b'\x08test\x0cstring\x0cstring\x04NA\xcc\xb8\xeb\xa6\x80_',

--- a/tests/integration/confluent/avromodel/test_avromodel_serializing.py
+++ b/tests/integration/confluent/avromodel/test_avromodel_serializing.py
@@ -24,7 +24,7 @@ class EvolvedEvent(Event):
     info: Optional[str] = 'test'
 
 
-def test_avro_producer_create_schema(sr_root_create: Path, topic: str, schema_description: Type[Event] = Event) -> None:
+def test_avro_producer_create_schema(sr_root_create: Path, topic: str, schema_description: type[Event] = Event) -> None:
     fixed_ts = 1632128298534
     test_producer = TestProducer()
     producer = HighLevelSerializingProducer(
@@ -51,7 +51,7 @@ def test_avro_producer_create_schema(sr_root_create: Path, topic: str, schema_de
 def test_avro_producer_existing_schema(
     sr_root_existing: Path,
     topic: str,
-    schema_description: Type[Event] = Event,
+    schema_description: type[Event] = Event,
 ) -> None:
     fixed_ts = 1632128298534
     test_producer = TestProducer()
@@ -79,7 +79,7 @@ def test_avro_producer_existing_schema(
 def test_avro_producer_update_schema(
     sr_root_update: Path,
     topic: str,
-    schema_description: Type[EvolvedEvent] = EvolvedEvent,
+    schema_description: type[EvolvedEvent] = EvolvedEvent,
 ) -> None:
     fixed_ts = 1632128298534
     test_producer = TestProducer()

--- a/tests/integration/confluent/avromodel/test_avromodel_serializing.py
+++ b/tests/integration/confluent/avromodel/test_avromodel_serializing.py
@@ -1,12 +1,12 @@
-from typing import Type, Optional
+from typing import Optional
 from pathlib import Path
 
 from pydantic import BaseModel
 
-from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.tests import TestProducer, TestHTTPClient
 from wunderkafka.serdes.avro import AvroModelSerializer
 from wunderkafka.serdes.store import AvroModelRepo
+from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.schema_registry import SimpleCache, ConfluentSRClient
 from wunderkafka.producers.constructor import HighLevelSerializingProducer
 

--- a/tests/integration/confluent/conftest.py
+++ b/tests/integration/confluent/conftest.py
@@ -1,6 +1,6 @@
-from dataclasses import dataclass
+from typing import Any
 from pathlib import Path
-from typing import Dict, Any
+from dataclasses import dataclass
 
 import pytest
 

--- a/tests/integration/confluent/conftest.py
+++ b/tests/integration/confluent/conftest.py
@@ -31,9 +31,9 @@ def sr_root_update(sr_root: Path) -> Path:
 
 
 @dataclass
-class Msg(object):
+class Msg:
     payload: bytes
-    deserialized: Dict[str, Any]
+    deserialized: dict[str, Any]
 
     def serialized(self, header: bytes) -> bytes:
         return header + self.payload

--- a/tests/integration/confluent/json/test_json_deserializing.py
+++ b/tests/integration/confluent/json/test_json_deserializing.py
@@ -48,7 +48,7 @@ def test_consume_moving_parts(sr_root_existing: Path, topic: str, header: bytes)
 
     consumer.subscribe([topic], from_beginning=True)
 
-    messages: List[Message] = consumer.consume()
+    messages: list[Message] = consumer.consume()
     [message] = messages
 
     assert message.value() == IMAGE_MESSAGE.deserialized

--- a/tests/integration/confluent/json/test_json_deserializing.py
+++ b/tests/integration/confluent/json/test_json_deserializing.py
@@ -1,21 +1,20 @@
-from typing import List, Optional
+from typing import Optional
 from pathlib import Path
 
 import pytest
-from pydantic import BaseModel, UUID4
+from pydantic import UUID4, BaseModel
 
 from wunderkafka.serdes.json import HAS_JSON_SCHEMA
 
 if not HAS_JSON_SCHEMA:
     pytest.skip("skipping json-schema-only tests", allow_module_level=True)
-from wunderkafka.serdes.json.deserializers import JSONDeserializer
-
-from tests.integration.confluent.conftest import Msg
-from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.tests import TestConsumer, TestHTTPClient
+from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.tests.consumer import Message
 from wunderkafka.schema_registry import SimpleCache, ConfluentSRClient
 from wunderkafka.consumers.constructor import HighLevelDeserializingConsumer
+from tests.integration.confluent.conftest import Msg
+from wunderkafka.serdes.json.deserializers import JSONDeserializer
 
 
 class Image(BaseModel):

--- a/tests/integration/confluent/json/test_json_serializing.py
+++ b/tests/integration/confluent/json/test_json_serializing.py
@@ -2,18 +2,16 @@ from pathlib import Path
 
 import pytest
 
-
 from wunderkafka.serdes.json import HAS_JSON_SCHEMA
 
 if not HAS_JSON_SCHEMA:
     pytest.skip("skipping json-schema-only tests", allow_module_level=True)
-from wunderkafka.serdes.store import JSONRepo
-from wunderkafka.serdes.json.serializers import JSONSerializer
-
-from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.tests import TestProducer, TestHTTPClient
+from wunderkafka.serdes.store import JSONRepo
+from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.schema_registry import SimpleCache, ConfluentSRClient
 from wunderkafka.producers.constructor import HighLevelSerializingProducer
+from wunderkafka.serdes.json.serializers import JSONSerializer
 
 
 def test_json_producer_create_schema(sr_root_existing: Path) -> None:

--- a/tests/integration/confluent/jsonmodel/test_jsonmodel_serializing.py
+++ b/tests/integration/confluent/jsonmodel/test_jsonmodel_serializing.py
@@ -1,21 +1,20 @@
+from uuid import UUID
 from typing import Optional
 from pathlib import Path
-from uuid import UUID
 
 import pytest
-from pydantic import BaseModel, UUID4
+from pydantic import UUID4, BaseModel
 
 from wunderkafka.serdes.json import HAS_JSON_SCHEMA
 from wunderkafka.serdes.store import JSONModelRepo
 
 if not HAS_JSON_SCHEMA:
     pytest.skip("skipping json-schema-only tests", allow_module_level=True)
-from wunderkafka.serdes.jsonmodel.serializers import JSONModelSerializer
-
-from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.tests import TestProducer, TestHTTPClient
+from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.schema_registry import SimpleCache, ConfluentSRClient
 from wunderkafka.producers.constructor import HighLevelSerializingProducer
+from wunderkafka.serdes.jsonmodel.serializers import JSONModelSerializer
 
 
 class Image(BaseModel):

--- a/tests/integration/confluent/mixed/test_string_avro_deserializing.py
+++ b/tests/integration/confluent/mixed/test_string_avro_deserializing.py
@@ -44,7 +44,7 @@ def test_consume_moving_parts(sr_root_existing: Path, topic: str, header: bytes)
 
     consumer.subscribe([topic], from_beginning=True)
 
-    messages: List[Message] = consumer.consume()
+    messages: list[Message] = consumer.consume()
     [message] = messages
     assert message.key() == '1632128298534'
     assert message.value() == SIGNAL_MESSAGE.deserialized

--- a/tests/integration/confluent/mixed/test_string_avro_deserializing.py
+++ b/tests/integration/confluent/mixed/test_string_avro_deserializing.py
@@ -1,18 +1,15 @@
-from typing import List
 from pathlib import Path
 
 import pytest
 
-from tests.integration.confluent.conftest import Msg
-from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
-from wunderkafka.serdes.schemaless.string.deserializers import StringDeserializer
-
 from wunderkafka.tests import TestConsumer, TestHTTPClient
 from wunderkafka.serdes.avro import FastAvroDeserializer
+from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.tests.consumer import Message
 from wunderkafka.schema_registry import SimpleCache, ConfluentSRClient
 from wunderkafka.consumers.constructor import HighLevelDeserializingConsumer
-
+from tests.integration.confluent.conftest import Msg
+from wunderkafka.serdes.schemaless.string.deserializers import StringDeserializer
 
 SIGNAL_MESSAGE = Msg(
     payload=b'\x08test\x0cstring\x0cstring\x04NA\xcc\xb8\xeb\xa6\x80_',

--- a/tests/integration/confluent/mixed/test_string_avromodel_serializing.py
+++ b/tests/integration/confluent/mixed/test_string_avromodel_serializing.py
@@ -1,18 +1,16 @@
+from uuid import UUID
 from typing import Optional
 from pathlib import Path
-from uuid import UUID
 
-from pydantic import BaseModel, UUID4
+from pydantic import UUID4, BaseModel
 
-from wunderkafka.serdes.avromodel.serializers import AvroModelSerializer
-from wunderkafka.serdes.schemaless.string.serializers import StringSerializer
-from wunderkafka.serdes.store import AvroModelRepo
-
-
-from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.tests import TestProducer, TestHTTPClient
+from wunderkafka.serdes.store import AvroModelRepo
+from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.schema_registry import SimpleCache, ConfluentSRClient
 from wunderkafka.producers.constructor import HighLevelSerializingProducer
+from wunderkafka.serdes.avromodel.serializers import AvroModelSerializer
+from wunderkafka.serdes.schemaless.string.serializers import StringSerializer
 
 
 class Image(BaseModel):

--- a/tests/integration/confluent/mixed/test_string_json_deserializing.py
+++ b/tests/integration/confluent/mixed/test_string_json_deserializing.py
@@ -1,4 +1,3 @@
-from typing import List
 from pathlib import Path
 
 import pytest
@@ -8,14 +7,13 @@ from wunderkafka.serdes.schemaless.string.deserializers import StringDeserialize
 
 if not HAS_JSON_SCHEMA:
     pytest.skip("skipping json-schema-only tests", allow_module_level=True)
-from tests.integration.confluent.conftest import Msg
-from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
-
 from wunderkafka.tests import TestConsumer, TestHTTPClient
-from wunderkafka.serdes.json.deserializers import JSONDeserializer
+from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.tests.consumer import Message
 from wunderkafka.schema_registry import SimpleCache, ConfluentSRClient
 from wunderkafka.consumers.constructor import HighLevelDeserializingConsumer
+from tests.integration.confluent.conftest import Msg
+from wunderkafka.serdes.json.deserializers import JSONDeserializer
 
 MESSAGE = Msg(
     payload=b'{"id": "714fc713-37ff-4477-9157-cb4f14b63e1a", "path": "/var/folders/x5/zlpmj3915pqfj5lhnlq5qwkm0000gn/T/tmprq2rktq3"}',

--- a/tests/integration/confluent/mixed/test_string_json_deserializing.py
+++ b/tests/integration/confluent/mixed/test_string_json_deserializing.py
@@ -44,7 +44,7 @@ def test_consume_moving_parts(sr_root_existing: Path, topic: str, header: bytes)
 
     consumer.subscribe([topic], from_beginning=True)
 
-    messages: List[Message] = consumer.consume()
+    messages: list[Message] = consumer.consume()
     [message] = messages
     assert message.key() == '714fc713-37ff-4477-9157-cb4f14b63e1a'
     assert message.value() == MESSAGE.deserialized

--- a/tests/integration/confluent/mixed/test_string_jsonmodel_serializing.py
+++ b/tests/integration/confluent/mixed/test_string_jsonmodel_serializing.py
@@ -1,9 +1,9 @@
+from uuid import UUID
 from typing import Optional
 from pathlib import Path
-from uuid import UUID
 
 import pytest
-from pydantic import BaseModel, UUID4
+from pydantic import UUID4, BaseModel
 
 from wunderkafka.serdes.json import HAS_JSON_SCHEMA
 from wunderkafka.serdes.schemaless.string.serializers import StringSerializer
@@ -11,11 +11,11 @@ from wunderkafka.serdes.schemaless.string.serializers import StringSerializer
 if not HAS_JSON_SCHEMA:
     pytest.skip("skipping json-schema-only tests", allow_module_level=True)
 
-from wunderkafka.serdes.jsonmodel.serializers import JSONModelSerializer
-from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.tests import TestProducer, TestHTTPClient
+from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.schema_registry import SimpleCache, ConfluentSRClient
 from wunderkafka.producers.constructor import HighLevelSerializingProducer
+from wunderkafka.serdes.jsonmodel.serializers import JSONModelSerializer
 
 
 class Image(BaseModel):

--- a/tests/integration/confluent/string/test_string_string.py
+++ b/tests/integration/confluent/string/test_string_string.py
@@ -1,11 +1,11 @@
 from typing import Optional
 from pathlib import Path
 
-from pydantic import BaseModel, UUID4
+from pydantic import UUID4, BaseModel
 
-from wunderkafka.serdes.schemaless.string.serializers import StringSerializer
 from wunderkafka.tests import TestProducer
 from wunderkafka.producers.constructor import HighLevelSerializingProducer
+from wunderkafka.serdes.schemaless.string.serializers import StringSerializer
 
 
 class Image(BaseModel):

--- a/tests/integration/schemaless/test_string_json_deserializing.py
+++ b/tests/integration/schemaless/test_string_json_deserializing.py
@@ -36,7 +36,7 @@ def test_consume_moving_parts(topic: str) -> None:
 
     consumer.subscribe([topic], from_beginning=True)
 
-    messages: List[Message] = consumer.consume()
+    messages: list[Message] = consumer.consume()
     [message] = messages
     assert message.key() == '714fc713-37ff-4477-9157-cb4f14b63e1a'
     assert message.value() == MESSAGE.deserialized

--- a/tests/integration/schemaless/test_string_json_deserializing.py
+++ b/tests/integration/schemaless/test_string_json_deserializing.py
@@ -1,18 +1,16 @@
-from typing import List
-
 import pytest
 
-
 from wunderkafka.serdes.json import HAS_JSON_SCHEMA
+
 if not HAS_JSON_SCHEMA:
     pytest.skip("skipping json-schema-only tests", allow_module_level=True)
 
-from wunderkafka.serdes.schemaless.json.deserializers import SchemaLessJSONDeserializer
-from wunderkafka.serdes.schemaless.string.deserializers import StringDeserializer
 from wunderkafka.tests import TestConsumer
 from wunderkafka.tests.consumer import Message
 from wunderkafka.consumers.constructor import HighLevelDeserializingConsumer
 from tests.integration.confluent.conftest import Msg
+from wunderkafka.serdes.schemaless.json.deserializers import SchemaLessJSONDeserializer
+from wunderkafka.serdes.schemaless.string.deserializers import StringDeserializer
 
 MESSAGE = Msg(
     payload=b'{"id": "714fc713-37ff-4477-9157-cb4f14b63e1a", "path": "/var/folders/x5/zlpmj3915pqfj5lhnlq5qwkm0000gn/T/tmprq2rktq3"}',

--- a/tests/integration/schemaless/test_string_jsonmodel_serializing.py
+++ b/tests/integration/schemaless/test_string_jsonmodel_serializing.py
@@ -1,14 +1,13 @@
 import uuid
-from typing import Optional
 from uuid import UUID
+from typing import Optional
 
 import pytest
 from pydantic import BaseModel
 
 from wunderkafka.serdes.json import HAS_JSON_SCHEMA
-from wunderkafka.serdes.schemaless.jsonmodel.serializers import SchemaLessJSONModelSerializer
-
 from wunderkafka.serdes.schemaless.string.serializers import StringSerializer
+from wunderkafka.serdes.schemaless.jsonmodel.serializers import SchemaLessJSONModelSerializer
 
 if not HAS_JSON_SCHEMA:
     pytest.skip("skipping json-schema-only tests", allow_module_level=True)

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -5,7 +5,7 @@ from pytest import FixtureRequest
 
 from wunderkafka import SecurityProtocol
 
-RawConfig = Dict[str, Any]
+RawConfig = dict[str, Any]
 
 
 @pytest.fixture

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 import pytest
 from pytest import FixtureRequest

--- a/tests/smoke/test_callbacks.py
+++ b/tests/smoke/test_callbacks.py
@@ -6,7 +6,7 @@ from confluent_kafka import KafkaError
 from wunderkafka.callbacks import info_callback, error_callback
 
 
-class Message(object):
+class Message:
 
     def topic(self) -> str:
         return 'test'
@@ -19,6 +19,6 @@ class Message(object):
 @pytest.mark.parametrize("callback_args", [(None, Message()), (KafkaError(10), Message())])
 def test_just_print(
     callback: Callable[[Optional[KafkaError], Message], Any],
-    callback_args: Tuple[Optional[KafkaError], Message],
+    callback_args: tuple[Optional[KafkaError], Message],
 ) -> None:
     callback(*callback_args)

--- a/tests/smoke/test_callbacks.py
+++ b/tests/smoke/test_callbacks.py
@@ -1,4 +1,4 @@
-from typing import Any, Tuple, Callable, Optional
+from typing import Any, Callable, Optional
 
 import pytest
 from confluent_kafka import KafkaError

--- a/tests/smoke/test_config_krb.py
+++ b/tests/smoke/test_config_krb.py
@@ -1,5 +1,5 @@
-from tests.smoke.conftest import RawConfig
 from wunderkafka import ConsumerConfig, ProducerConfig
+from tests.smoke.conftest import RawConfig
 from wunderkafka.config.krb.rdkafka import config_requires_kerberos
 
 

--- a/tests/smoke/test_configs.py
+++ b/tests/smoke/test_configs.py
@@ -1,8 +1,8 @@
 import pytest
 from pydantic import ValidationError
 
-from tests.smoke.conftest import RawConfig
 from wunderkafka import SRConfig, BytesConsumer, BytesProducer, ConsumerConfig, ProducerConfig
+from tests.smoke.conftest import RawConfig
 
 
 def test_init_consumer(boostrap_servers: str) -> None:

--- a/tests/unit/derive/test_avro_base_model.py
+++ b/tests/unit/derive/test_avro_base_model.py
@@ -1,8 +1,7 @@
 import json
-from typing import List
 
-from dataclasses_avroschema.pydantic import AvroBaseModel
 from pydantic import UUID4
+from dataclasses_avroschema.pydantic import AvroBaseModel
 
 from wunderkafka.serdes.avromodel import derive
 

--- a/tests/unit/derive/test_avro_base_model.py
+++ b/tests/unit/derive/test_avro_base_model.py
@@ -13,7 +13,7 @@ class AvroNestedClass(AvroBaseModel):
 
 class AvroResultClass(AvroBaseModel):
     id: UUID4
-    nested: List[AvroNestedClass]
+    nested: list[AvroNestedClass]
 
 
 class AvroSimilarImage(AvroBaseModel):

--- a/tests/unit/derive/test_base_classes.py
+++ b/tests/unit/derive/test_base_classes.py
@@ -1,17 +1,16 @@
-import json
 import sys
+import json
 import time
-from typing import Optional, Union, List
+from typing import Union, Optional
 from datetime import datetime
 from dataclasses import dataclass
 
 import pytest
-from pydantic import Field, BaseModel, ValidationError, ConfigDict, UUID4
+from pydantic import UUID4, Field, BaseModel, ConfigDict, ValidationError
 from pydantic_settings import BaseSettings
-
 from dataclasses_avroschema import AvroModel
-from wunderkafka.serdes.avromodel import derive
 
+from wunderkafka.serdes.avromodel import derive
 
 # ToDo (tribunsky.kir): review some tests. As pydantic V2 changes it's behaviour, some tests are useless:
 #                       we still can derive correct model, but we will be unable to actually populate it in runtime.

--- a/tests/unit/derive/test_base_classes.py
+++ b/tests/unit/derive/test_base_classes.py
@@ -126,7 +126,7 @@ class Item(BaseModel):
 
 
 class ItemList(BaseModel):
-    items: Optional[List[Item]] = None
+    items: Optional[list[Item]] = None
 
 
 def test_dataclass() -> None:

--- a/tests/unit/derive/test_nested.py
+++ b/tests/unit/derive/test_nested.py
@@ -1,9 +1,9 @@
 import json
+from typing import Optional
 from pathlib import Path
-from typing import List, Optional, Dict
 
 import pytest
-from pydantic import BaseModel, UUID4, ValidationError
+from pydantic import UUID4, BaseModel, ValidationError
 from pydantic_settings import BaseSettings
 
 from wunderkafka.serdes.avromodel import derive

--- a/tests/unit/derive/test_nested.py
+++ b/tests/unit/derive/test_nested.py
@@ -32,7 +32,7 @@ def test_simple_base_model() -> None:
 
 class ResultModel(BaseModel):
     id: UUID4
-    nested: List[NestedModel]
+    nested: list[NestedModel]
 
 
 def test_nested_base_model_list() -> None:
@@ -73,7 +73,7 @@ def test_nested_base_model_list() -> None:
 
 
 class HasDictStrSchema(BaseModel):
-    dct: Dict[str, NestedModel]
+    dct: dict[str, NestedModel]
 
 
 def test_nested_base_model_dict_str_key() -> None:
@@ -107,7 +107,7 @@ def test_nested_base_model_dict_str_key() -> None:
 
 
 class HasDictIntSchema(BaseModel):
-    dct: Dict[int, NestedModel]
+    dct: dict[int, NestedModel]
 
 
 def test_nested_base_model_dict_int_key() -> None:

--- a/tests/unit/test_fs_repo.py
+++ b/tests/unit/test_fs_repo.py
@@ -1,11 +1,11 @@
 import json
-from typing import Any, Dict
+from typing import Any
 from pathlib import Path
 
 import pytest
 
-from wunderkafka.serdes.store import SchemaFSRepo
 from wunderkafka.structures import SchemaType
+from wunderkafka.serdes.store import SchemaFSRepo
 
 
 @pytest.fixture

--- a/tests/unit/test_fs_repo.py
+++ b/tests/unit/test_fs_repo.py
@@ -19,7 +19,7 @@ def fs_root_dir(fixtures_root: Path) -> Path:
 
 
 @pytest.fixture
-def answer_json() -> Dict[str, Any]:
+def answer_json() -> dict[str, Any]:
     return {
      "type": "record",
      "name": "exampleSchema",
@@ -45,7 +45,7 @@ def test_fs_repo(
     key_schema_path: str,
     value_schema_path: str,
     fs_root_dir: Path,
-    answer_json: Dict[str, Any]
+    answer_json: dict[str, Any]
 ) -> None:
     repo.add(topic, fs_root_dir / value_schema_path, fs_root_dir / key_schema_path)
     key_schema = repo.get(topic, is_key=True)

--- a/tests/unit/test_generate.py
+++ b/tests/unit/test_generate.py
@@ -1,4 +1,3 @@
-from typing import Dict, List
 from pathlib import Path
 
 import pytest

--- a/tests/unit/test_generate.py
+++ b/tests/unit/test_generate.py
@@ -14,7 +14,7 @@ from wunderkafka.config.generate import (
 )
 
 
-def read_answer(root: Path, file_name: str) -> List[str]:
+def read_answer(root: Path, file_name: str) -> list[str]:
     with open(root / 'answers' / file_name) as fl:
         return fl.read().split('\n')[:-1]
 
@@ -30,36 +30,36 @@ def configuration_md(fixture_root: Path) -> Path:
 
 
 @pytest.fixture
-def enums(fixture_root: Path) -> List[str]:
+def enums(fixture_root: Path) -> list[str]:
     return read_answer(fixture_root, 'enums.py')
 
 
 @pytest.fixture
-def fields(fixture_root: Path) -> List[str]:
+def fields(fixture_root: Path) -> list[str]:
     return read_answer(fixture_root, 'fields.py')
 
 
 @pytest.fixture
-def models(fixture_root: Path) -> List[str]:
+def models(fixture_root: Path) -> list[str]:
     return read_answer(fixture_root, 'models.py')
 
 
 @pytest.fixture
-def grouped(configuration_md: Path) -> Dict[str, List[Row]]:
+def grouped(configuration_md: Path) -> dict[str, list[Row]]:
     return group(parse(read_markdown(filename=configuration_md)))
 
 
-def test_enums(grouped: Dict[str, List[Row]], enums: List[str]) -> None:
+def test_enums(grouped: dict[str, list[Row]], enums: list[str]) -> None:
     generated = generate_enums(grouped)
     assert enums == generated
 
 
-def test_fields(grouped: Dict[str, List[Row]], fields: List[str]) -> None:
+def test_fields(grouped: dict[str, list[Row]], fields: list[str]) -> None:
     generated = generate_fields(grouped)
     assert fields == generated
 
 
-def test_models(grouped: Dict[str, List[Row]], models: List[str]) -> None:
+def test_models(grouped: dict[str, list[Row]], models: list[str]) -> None:
     generated = generate_models(grouped)
     # Multiline for builtin
     assert models == '\n'.join(generated).split('\n')

--- a/tests/unit/test_krb_timeout.py
+++ b/tests/unit/test_krb_timeout.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import datetime
 
 import pytest

--- a/tests/unit/test_krb_timeout.py
+++ b/tests/unit/test_krb_timeout.py
@@ -2,7 +2,7 @@ import datetime
 
 import pytest
 
-from wunderkafka.hotfixes.watchdog.krb.ticket import clean_stdout, get_datetime, HAS_DATEUTIL
+from wunderkafka.hotfixes.watchdog.krb.ticket import HAS_DATEUTIL, clean_stdout, get_datetime
 
 STDOUT1 = """
 Ticket cache: FILE:/tmp/krb5cc_1000

--- a/tests/unit/test_parse_kinit.py
+++ b/tests/unit/test_parse_kinit.py
@@ -1,6 +1,6 @@
 import pytest
 
-from wunderkafka.hotfixes.watchdog import parse_kinit, KinitParams
+from wunderkafka.hotfixes.watchdog import KinitParams, parse_kinit
 
 USER = 'my.user'
 REALM = 'MYDOMAIN.COM'

--- a/tests/unit/test_parse_kinit.py
+++ b/tests/unit/test_parse_kinit.py
@@ -8,8 +8,8 @@ REALM = 'MYDOMAIN.COM'
 
 @pytest.mark.parametrize(
     'keytab',
-    ['{0}.keytab'.format(USER), '/home/{0}@{1}/{0}.keytab'.format(USER, REALM.lower())]
+    [f'{USER}.keytab', '/home/{0}@{1}/{0}.keytab'.format(USER, REALM.lower())]
 )
 def test_parse_kinit(keytab: str) -> None:
-    kinit_cmd = 'kinit {0}@{1} -k -t {2}'.format(USER, REALM, keytab)
+    kinit_cmd = f'kinit {USER}@{REALM} -k -t {keytab}'
     assert parse_kinit(kinit_cmd) == KinitParams(user=USER, realm=REALM, keytab=keytab, cmd=kinit_cmd)

--- a/tests/unit/test_serialize_shemaless_json.py
+++ b/tests/unit/test_serialize_shemaless_json.py
@@ -5,10 +5,10 @@ import datetime
 from uuid import UUID
 
 import pytest
-from pydantic import BaseModel, Field
+from pydantic import Field, BaseModel
 
-from wunderkafka.serdes.schemaless.jsonmodel.serializers import SchemaLessJSONModelSerializer
 from wunderkafka.serdes.schemaless.json.serializers import SchemaLessJSONSerializer
+from wunderkafka.serdes.schemaless.jsonmodel.serializers import SchemaLessJSONModelSerializer
 
 
 def get_random_string() -> str:

--- a/wunderkafka/__init__.py
+++ b/wunderkafka/__init__.py
@@ -34,3 +34,31 @@ from wunderkafka.config.generated.enums import (
 )
 from wunderkafka.config.schema_registry import SRConfig
 from wunderkafka.consumers.subscription import TopicSubscription
+
+
+__all__ = [
+    'Message',
+    'ConsumerConfig', 
+    'ProducerConfig',
+    'AnyConsumer', 
+    'AnyProducer',
+    'AvroConsumer',
+    'AvroProducer',
+    'AvroModelProducer',
+    'AvroClouderaConsumer',
+    'AvroConfluentConsumer',
+    'AvroModelClouderaProducer',
+    'AvroModelConfluentProducer',
+    'BytesConsumer',
+    'BytesProducer',
+    'IsolationLevel',
+    'AutoOffsetReset',
+    'CompressionType',
+    'QueuingStrategy',
+    'CompressionCodec',
+    'SecurityProtocol',
+    'BrokerAddressFamily',
+    'SslEndpointIdentificationAlgorithm',
+    'SRConfig',
+    'TopicSubscription',
+]

--- a/wunderkafka/__init__.py
+++ b/wunderkafka/__init__.py
@@ -10,6 +10,7 @@ Module contains handful re-imports (public API) from the package.
 from confluent_kafka import Message
 
 from wunderkafka.config import ConsumerConfig, ProducerConfig
+from wunderkafka.protocols import AnyConsumer, AnyProducer
 from wunderkafka.factories.avro import (
     AvroConsumer,
     AvroProducer,
@@ -19,7 +20,6 @@ from wunderkafka.factories.avro import (
     AvroModelClouderaProducer,
     AvroModelConfluentProducer,
 )
-from wunderkafka.protocols import AnyConsumer, AnyProducer
 from wunderkafka.consumers.bytes import BytesConsumer
 from wunderkafka.producers.bytes import BytesProducer
 from wunderkafka.config.generated.enums import (

--- a/wunderkafka/callbacks.py
+++ b/wunderkafka/callbacks.py
@@ -10,7 +10,7 @@ from wunderkafka.consumers.abc import AbstractConsumer
 
 
 # FixMe (tribunsky.kir): do not mutate consumer from here, try to closure it in consumer itself.
-def reset_partitions(consumer: AbstractConsumer, partitions: List[TopicPartition]) -> None:
+def reset_partitions(consumer: AbstractConsumer, partitions: list[TopicPartition]) -> None:
     """
     Set specific offset for assignment after subscription.
 
@@ -22,7 +22,7 @@ def reset_partitions(consumer: AbstractConsumer, partitions: List[TopicPartition
     new_offsets = consumer.subscription_offsets
     if new_offsets is None:
         logger.warning(
-            '{0}: re-assigned (using auto.offset.reset={1})'.format(consumer, consumer.config.auto_offset_reset),
+            f'{consumer}: re-assigned (using auto.offset.reset={consumer.config.auto_offset_reset})',
         )
         return
     by_offset = []
@@ -34,7 +34,7 @@ def reset_partitions(consumer: AbstractConsumer, partitions: List[TopicPartition
         else:
             partition.offset = new_offset.value
             if isinstance(new_offset, Timestamp):
-                logger.info('Setting {0}...'.format(new_offset))
+                logger.info(f'Setting {new_offset}...')
                 by_ts.append(partition)
             else:
                 by_offset.append(partition)
@@ -42,7 +42,7 @@ def reset_partitions(consumer: AbstractConsumer, partitions: List[TopicPartition
         by_ts = consumer.offsets_for_times(by_ts)
     new_ptns = by_ts + by_offset
     consumer.assign(new_ptns)
-    logger.info('{0} assigned to {1}'.format(consumer, new_ptns))
+    logger.info(f'{consumer} assigned to {new_ptns}')
     consumer.subscription_offsets = None
 
 
@@ -54,9 +54,9 @@ def info_callback(err: Optional[KafkaError], msg: Message) -> None:
     :param msg:             Message to be delivered.
     """
     if err is None:
-        logger.info('Message delivered to {0} partition: {1}'.format(msg.topic(), msg.partition()))
+        logger.info(f'Message delivered to {msg.topic()} partition: {msg.partition()}')
     else:
-        logger.error('Message failed delivery: {0}'.format(err))
+        logger.error(f'Message failed delivery: {err}')
 
 
 def error_callback(err: Optional[KafkaError], _: Message) -> None:
@@ -67,4 +67,4 @@ def error_callback(err: Optional[KafkaError], _: Message) -> None:
     :param _:               Message to be delivered (unused, but needed to not break callback signature).
     """
     if err:
-        logger.error('Message failed delivery: {0}'.format(err))
+        logger.error(f'Message failed delivery: {err}')

--- a/wunderkafka/callbacks.py
+++ b/wunderkafka/callbacks.py
@@ -1,6 +1,6 @@
 """This module contains some predefined callbacks to interact with librdkafka."""
 
-from typing import List, Optional
+from typing import Optional
 
 from confluent_kafka import Message, KafkaError, TopicPartition
 

--- a/wunderkafka/compat.py
+++ b/wunderkafka/compat.py
@@ -1,6 +1,11 @@
 import sys
 
 if sys.version_info >= (3, 10):
-    pass
+    from typing import ParamSpec
 else:
-    pass
+    from typing_extensions import ParamSpec
+
+
+__all__ = [
+    'ParamSpec',
+]

--- a/wunderkafka/compat.py
+++ b/wunderkafka/compat.py
@@ -1,6 +1,6 @@
 import sys
 
 if sys.version_info >= (3, 10):
-    from typing import ParamSpec
+    pass
 else:
-    from typing_extensions import ParamSpec
+    pass

--- a/wunderkafka/config/__init__.py
+++ b/wunderkafka/config/__init__.py
@@ -1,1 +1,7 @@
 from wunderkafka.config.rdkafka import ConsumerConfig, ProducerConfig
+
+
+__all__ = [
+    'ConsumerConfig',
+    'ProducerConfig',
+]

--- a/wunderkafka/config/generate.py
+++ b/wunderkafka/config/generate.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import logging
 import operator
-from typing import Dict, List, Tuple, Union, Optional, NamedTuple
+from typing import Union, Optional, NamedTuple
 from pathlib import Path
 from collections import defaultdict
 

--- a/wunderkafka/config/generated/enums.py
+++ b/wunderkafka/config/generated/enums.py
@@ -9,7 +9,6 @@
 
 from wunderkafka import librdkafka
 
-
 if librdkafka.__version__ >= (2, 8, 0):
     from wunderkafka.config.generated._2_8_0.enums import *  # type: ignore[assignment]
 if librdkafka.__version__ >= (2, 7, 0):

--- a/wunderkafka/config/generated/fields.py
+++ b/wunderkafka/config/generated/fields.py
@@ -9,7 +9,6 @@
 
 from wunderkafka import librdkafka
 
-
 if librdkafka.__version__ >= (2, 8, 0):
     from wunderkafka.config.generated._2_8_0.fields import *  # type: ignore[assignment]
 if librdkafka.__version__ >= (2, 7, 0):

--- a/wunderkafka/config/generated/models.py
+++ b/wunderkafka/config/generated/models.py
@@ -9,7 +9,6 @@
 
 from wunderkafka import librdkafka
 
-
 if librdkafka.__version__ >= (2, 8, 0):
     from wunderkafka.config.generated._2_8_0.models import *  # type: ignore[assignment]
 if librdkafka.__version__ >= (2, 7, 0):

--- a/wunderkafka/config/krb/rdkafka.py
+++ b/wunderkafka/config/krb/rdkafka.py
@@ -42,6 +42,6 @@ def challenge_krb_arg(exc: KafkaError, config: RDKafkaConfig) -> RDKafkaConfig:
         ]))
         old = config.builtin_features
         new = exclude_gssapi(config.builtin_features)
-        logger.warning('Changing builtin.features: {0} -> {1}'.format(old, new))
+        logger.warning(f'Changing builtin.features: {old} -> {new}')
         config.builtin_features = new
         return config

--- a/wunderkafka/config/krb/rdkafka.py
+++ b/wunderkafka/config/krb/rdkafka.py
@@ -1,8 +1,8 @@
 from confluent_kafka import KafkaError
 
-from wunderkafka.config.generated import enums
-from wunderkafka.config.rdkafka import RDKafkaConfig
 from wunderkafka.logger import logger
+from wunderkafka.config.rdkafka import RDKafkaConfig
+from wunderkafka.config.generated import enums
 
 
 def exclude_gssapi(builtin_features: str) -> str:

--- a/wunderkafka/config/rdkafka.py
+++ b/wunderkafka/config/rdkafka.py
@@ -1,7 +1,8 @@
 import os
 from enum import Enum
 from types import MappingProxyType
-from typing import Any, Dict, Union, Mapping, TypeVar, Optional
+from typing import Any, Dict, Union, TypeVar, Optional
+from collections.abc import Mapping
 
 from wunderkafka.config.schema_registry import SRConfig
 from wunderkafka.config.generated.fields import COMMON_FIELDS, CONSUMER_FIELDS, PRODUCER_FIELDS
@@ -20,9 +21,9 @@ ConfigValues = Union[str, int, bool, float]
 
 
 def remap_properties(
-    dct: Dict[str, Optional[ConfigValues]],
+    dct: dict[str, Optional[ConfigValues]],
     mapping: Mapping[str, str],
-) -> Dict[str, ConfigValues]:
+) -> dict[str, ConfigValues]:
     new_dct = {}
     for f_name, f_value in dct.items():
         if f_value is not None:
@@ -37,7 +38,7 @@ def remap_properties(
 #                       or write more complex generator and class hierarchy (e.g. platform-specific base classes)
 #                       to not monkeypatch config before actually feeding it to librdkafka.
 #                       #TypeSafety!!1
-def sanitize(dct: Dict[str, ConfigValues]) -> Dict[str, ConfigValues]:
+def sanitize(dct: dict[str, ConfigValues]) -> dict[str, ConfigValues]:
     # cimpl.KafkaException: KafkaError{
     #   ...
     #   "Configuration property "ssl.ca.certificate.stores" not supported in this build: configuration only valid on Windows"  # noqa: E501
@@ -46,7 +47,7 @@ def sanitize(dct: Dict[str, ConfigValues]) -> Dict[str, ConfigValues]:
         property_name = 'ssl.ca.certificate.stores'
         property_value = dct.pop(property_name, None)
         if property_value is not None:
-            logger.warning('Excluding {0}={1} as windows-only even it was set to default'.format(
+            logger.warning('Excluding {}={} as windows-only even it was set to default'.format(
                 property_name, property_value,
             ))
     return dct
@@ -58,7 +59,7 @@ class ConsumerConfig(RDConsumerConfig):
     # https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields
     sr: Optional[SRConfig] = None
 
-    def dict(self, **kwargs: Any) -> Dict[str, ConfigValues]:
+    def dict(self, **kwargs: Any) -> dict[str, ConfigValues]:
         dct = super().model_dump(**kwargs)
         dct.pop('sr')
         return sanitize(remap_properties(dct, CONF_CONSUMER_FIELDS))
@@ -68,7 +69,7 @@ class ProducerConfig(RDProducerConfig):
     # https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields
     sr: Optional[SRConfig] = None
 
-    def dict(self, **kwargs: Any) -> Dict[str, ConfigValues]:
+    def dict(self, **kwargs: Any) -> dict[str, ConfigValues]:
         dct = super().model_dump(**kwargs)
         dct.pop('sr')
         return sanitize(remap_properties(dct, CONF_PRODUCER_FIELDS))

--- a/wunderkafka/config/rdkafka.py
+++ b/wunderkafka/config/rdkafka.py
@@ -1,13 +1,13 @@
 import os
 from enum import Enum
 from types import MappingProxyType
-from typing import Any, Dict, Union, TypeVar, Optional
+from typing import Any, Union, TypeVar, Optional
 from collections.abc import Mapping
 
+from wunderkafka.logger import logger
 from wunderkafka.config.schema_registry import SRConfig
 from wunderkafka.config.generated.fields import COMMON_FIELDS, CONSUMER_FIELDS, PRODUCER_FIELDS
 from wunderkafka.config.generated.models import RDConsumerConfig, RDProducerConfig
-from wunderkafka.logger import logger
 
 CONF_CONSUMER_FIELDS = MappingProxyType({
     field_name.replace('.', '_'): field_name for field_name in (*COMMON_FIELDS, *CONSUMER_FIELDS)

--- a/wunderkafka/config/schema_registry.py
+++ b/wunderkafka/config/schema_registry.py
@@ -5,7 +5,7 @@ from pydantic_settings import BaseSettings
 from wunderkafka.config.krb.schema_registry import HTTPKerberosMutualAuth
 
 
-def remap_fields(dct: Dict[str, Any]) -> Dict[str, Any]:
+def remap_fields(dct: dict[str, Any]) -> dict[str, Any]:
     return {f_name.replace('_', '.'): f_value for f_name, f_value in dct.items()}
 
 
@@ -22,6 +22,6 @@ class SRConfig(BaseSettings):
     #                        but it entails writing additional logic for sasl username reuse.
     mutual_auth: Optional[HTTPKerberosMutualAuth] = None
 
-    def dict(self, **kwargs: Any) -> Dict[str, Optional[Union[str, int]]]:
+    def dict(self, **kwargs: Any) -> dict[str, Optional[Union[str, int]]]:
         dct = super().model_dump(**kwargs)
         return remap_fields(dct)

--- a/wunderkafka/config/schema_registry.py
+++ b/wunderkafka/config/schema_registry.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Union, Optional
+from typing import Any, Union, Optional
 
 from pydantic_settings import BaseSettings
 

--- a/wunderkafka/consumers/abc.py
+++ b/wunderkafka/consumers/abc.py
@@ -7,7 +7,7 @@ Module contains interface-like skeletons for consumer.
 
 import datetime
 from abc import ABC, abstractmethod
-from typing import Dict, List, Union, Optional
+from typing import Union, Optional
 
 from confluent_kafka import Message, Consumer, TopicPartition
 

--- a/wunderkafka/consumers/abc.py
+++ b/wunderkafka/consumers/abc.py
@@ -21,7 +21,7 @@ class AbstractConsumer(Consumer):
 
     # Why so: https://github.com/python/mypy/issues/4125
     _config: ConsumerConfig
-    subscription_offsets: Optional[Dict[str, HowToSubscribe]] = None
+    subscription_offsets: Optional[dict[str, HowToSubscribe]] = None
 
     @property
     def config(self) -> ConsumerConfig:
@@ -40,7 +40,7 @@ class AbstractConsumer(Consumer):
         num_messages: int = 1000000,
         *,
         raise_on_lost: bool = False,
-    ) -> List[Message]:
+    ) -> list[Message]:
         """
         Consume as many messages as we can for a given timeout.
 
@@ -68,9 +68,9 @@ class AbstractDeserializingConsumer(ABC):
     def commit(
         self,
         message: Optional[Message] = None,
-        offsets: Optional[List[TopicPartition]] = None,
+        offsets: Optional[list[TopicPartition]] = None,
         asynchronous: bool = True,
-    ) -> Optional[List[TopicPartition]]:
+    ) -> Optional[list[TopicPartition]]:
         """
         Commit a message or a list of offsets.
 
@@ -89,7 +89,7 @@ class AbstractDeserializingConsumer(ABC):
     @abstractmethod
     def subscribe(  # noqa: WPS211  # ToDo (tribunsky.kir): reconsider API of 'how'
         self,
-        topics: List[Union[str, TopicSubscription]],
+        topics: list[Union[str, TopicSubscription]],
         *,
         from_beginning: Optional[bool] = None,
         offset: Optional[int] = None,

--- a/wunderkafka/consumers/bytes.py
+++ b/wunderkafka/consumers/bytes.py
@@ -3,18 +3,18 @@
 import time
 import atexit
 import datetime
-from typing import Dict, List, Union, Optional, TypeVar, Callable
+from typing import Union, TypeVar, Callable, Optional
 
 import confluent_kafka
-from confluent_kafka import KafkaException, Consumer
+from confluent_kafka import Consumer, KafkaException
 
-from wunderkafka.config.krb.rdkafka import challenge_krb_arg
 from wunderkafka.types import HowToSubscribe
 from wunderkafka.config import ConsumerConfig
 from wunderkafka.errors import ConsumerException
 from wunderkafka.logger import logger
 from wunderkafka.callbacks import reset_partitions
 from wunderkafka.consumers.abc import Message, AbstractConsumer
+from wunderkafka.config.krb.rdkafka import challenge_krb_arg
 from wunderkafka.consumers.subscription import TopicSubscription
 
 

--- a/wunderkafka/consumers/bytes.py
+++ b/wunderkafka/consumers/bytes.py
@@ -32,7 +32,7 @@ class BytesConsumer(AbstractConsumer):
         except KafkaException as exc:
             config = challenge_krb_arg(exc, config)
             super().__init__(config.dict())
-        self.subscription_offsets: Optional[Dict[str, HowToSubscribe]] = None
+        self.subscription_offsets: Optional[dict[str, HowToSubscribe]] = None
 
         self._config = config
         self._last_poll_ts = time.perf_counter()
@@ -45,7 +45,7 @@ class BytesConsumer(AbstractConsumer):
 
         :return:    string with consumer gid.
         """
-        return '{0}:{1}'.format(self.__class__.__name__, self._config.group_id)
+        return f'{self.__class__.__name__}:{self._config.group_id}'
 
     def batch_poll(  # noqa: D102 # inherited from superclass.
         self,
@@ -53,12 +53,12 @@ class BytesConsumer(AbstractConsumer):
         num_messages: int = 1000000,
         *,
         raise_on_lost: bool = False,
-    ) -> List[Message]:
+    ) -> list[Message]:
 
         # ToDo (tribunsky.kir): naybe it better to use on_lost callback within subscribe()
         dt = int((time.perf_counter() - self._last_poll_ts) * 1000)
         if dt > self._config.max_poll_interval_ms:
-            msg = 'Exceeded max.poll.interval.ms ({0}): {1}'.format(self._config.max_poll_interval_ms, dt)
+            msg = f'Exceeded max.poll.interval.ms ({self._config.max_poll_interval_ms}): {dt}'
 
             if raise_on_lost:
                 # ToDo (tribunsky.kir): resubscribe by ts?
@@ -72,7 +72,7 @@ class BytesConsumer(AbstractConsumer):
     # ToDo (tribunsky.kir): do not override original API and wrap it in superclass
     def subscribe(  # noqa: D102,WPS211  # inherited from superclass.
         self,
-        topics: List[Union[str, TopicSubscription]],
+        topics: list[Union[str, TopicSubscription]],
         *,
         from_beginning: Optional[bool] = None,
         offset: Optional[int] = None,
@@ -112,7 +112,7 @@ def _patched_docstring(method: Callable[..., T], parent_method: Callable[..., T]
     current_doc = method.__doc__
     if not current_doc:
         return None
-    first, *_ = [line for line in current_doc.split('\n') if line]
+    first, *_ = (line for line in current_doc.split('\n') if line)
     spaces = 0
     for ch in first:
         if ch != ' ':
@@ -126,7 +126,7 @@ def _patched_docstring(method: Callable[..., T], parent_method: Callable[..., T]
     ])
     version_notes = [
         disclaimer,
-        "Below is the version rendered for version **{0}**:".format(confluent_kafka.__version__),
+        f"Below is the version rendered for version **{confluent_kafka.__version__}**:",
     ]
     version_note = '\n\n'.join(prefix + note for note in version_notes)
     original_doc = parent_method.__doc__ or ''
@@ -138,8 +138,8 @@ def _patched_docstring(method: Callable[..., T], parent_method: Callable[..., T]
                 intended.append(prefix + line)
             else:
                 intended.append(line)
-        original_doc = '\n\n{0}'.format('\n'.join(intended))
-    return '{0}\n{1}{2}'.format(current_doc, version_note, original_doc)
+        original_doc = '\n\n{}'.format('\n'.join(intended))
+    return f'{current_doc}\n{version_note}{original_doc}'
 
 
 BytesConsumer.subscribe.__doc__ = _patched_docstring(BytesConsumer.subscribe, Consumer.subscribe)

--- a/wunderkafka/consumers/constructor.py
+++ b/wunderkafka/consumers/constructor.py
@@ -8,17 +8,17 @@ All moving parts should be interchangeable in terms of schema, header and serial
 """
 
 import datetime
-from typing import Any, List, Union, Optional, TypeVar
+from typing import Any, Union, TypeVar, Optional
 
 from confluent_kafka import Message, TopicPartition
 from confluent_kafka.serialization import SerializationError
 
-from wunderkafka.consumers.types import StreamResult, PayloadError
 from wunderkafka.types import HeaderParser
 from wunderkafka.logger import logger
 from wunderkafka.serdes.abc import AbstractDeserializer
 from wunderkafka.structures import SchemaMeta, SchemaDescription
 from wunderkafka.consumers.abc import AbstractConsumer, AbstractDeserializingConsumer
+from wunderkafka.consumers.types import PayloadError, StreamResult
 from wunderkafka.schema_registry.abc import AbstractSchemaRegistry
 from wunderkafka.consumers.subscription import TopicSubscription
 

--- a/wunderkafka/consumers/constructor.py
+++ b/wunderkafka/consumers/constructor.py
@@ -33,8 +33,8 @@ def choose_one_of(
     chosen_deserializer = specific_deserializer if specific_deserializer else common_deserializer
     if chosen_deserializer is None:
         msg = [
-            '{0} deserializer is not specified,'.format(what.capitalize()),
-            'it should be passed via {0}_deserializer or deserializer at least.'.format(what),
+            f'{what.capitalize()} deserializer is not specified,',
+            f'it should be passed via {what}_deserializer or deserializer at least.',
         ]
         raise ValueError(' '.join(msg))
     return chosen_deserializer
@@ -77,7 +77,7 @@ class HighLevelDeserializingConsumer(AbstractDeserializingConsumer):
 
     def subscribe(  # noqa: D102,WPS211 # docstring inherited from superclass.
         self,
-        topics: List[Union[str, TopicSubscription]],
+        topics: list[Union[str, TopicSubscription]],
         *,
         from_beginning: Optional[bool] = None,
         offset: Optional[int] = None,
@@ -91,9 +91,9 @@ class HighLevelDeserializingConsumer(AbstractDeserializingConsumer):
     def commit(  # noqa: D102,WPS211 # docstring inherited from superclass.
         self,
         message: Optional[Message] = None,
-        offsets: Optional[List[TopicPartition]] = None,
+        offsets: Optional[list[TopicPartition]] = None,
         asynchronous: bool = True,
-    ) -> Optional[List[TopicPartition]]:
+    ) -> Optional[list[TopicPartition]]:
         if message is None and offsets is not None:
             return self.consumer.commit(offsets=offsets, asynchronous=asynchronous)
         if message is not None and offsets is None:
@@ -109,7 +109,7 @@ class HighLevelDeserializingConsumer(AbstractDeserializingConsumer):
         ignore_keys: bool = False,
         raise_on_error: bool = True,
         raise_on_lost: bool = True,
-    ) -> List[T]:
+    ) -> list[T]:
         """
         Consume as many messages as we can for a given timeout and decode them.
 
@@ -132,8 +132,8 @@ class HighLevelDeserializingConsumer(AbstractDeserializingConsumer):
             raise_on_error=raise_on_error,
         )
 
-    def _decoded(self, msgs: List[Message], *, ignore_keys: bool, raise_on_error: bool) -> List[T]:
-        results: List[StreamResult] = []
+    def _decoded(self, msgs: list[Message], *, ignore_keys: bool, raise_on_error: bool) -> list[T]:
+        results: list[StreamResult] = []
         for msg in msgs:
             kafka_error = msg.error()
             # Not sure if there is any need for an option to exclude errored message from the consumed ones,
@@ -161,7 +161,7 @@ class HighLevelDeserializingConsumer(AbstractDeserializingConsumer):
                 # KeyDeserializationError is inherited from SerializationError
                 except SerializationError:
                     decode_key_ok = False
-                    logger.error("Unable to decode key from bytes: {0}".format(raw_key_value))
+                    logger.error(f"Unable to decode key from bytes: {raw_key_value}")
                     if not ignore_keys:
                         raise
                 else:
@@ -170,14 +170,14 @@ class HighLevelDeserializingConsumer(AbstractDeserializingConsumer):
             try:
                 decoded_value = self._decode(topic, msg.value())
             except (SerializationError, ValueError) as exc:
-                logger.error("Unable to decode value from bytes: {0}".format(msg.value()))
+                logger.error(f"Unable to decode value from bytes: {msg.value()}")
                 if not self._stream_result:
                     raise
                 value_error = str(exc)
                 if decode_key_ok:
                     error = PayloadError(description=value_error)
                 else:
-                    message = "Unable to decode key (topic: {0}, key payload: {1})".format(topic, raw_key_value)
+                    message = f"Unable to decode key (topic: {topic}, key payload: {raw_key_value})"
                     error = PayloadError(description=message)
                 results.append(StreamResult(payload=None, error=error, msg=msg))
             else:

--- a/wunderkafka/consumers/subscription.py
+++ b/wunderkafka/consumers/subscription.py
@@ -42,7 +42,7 @@ def choose_offset(
     return None
 
 
-class TopicSubscription(object):
+class TopicSubscription:
     """Allows custom definition of subscription for topic without need to build full TopicPartition list."""
 
     def __init__(  # noqa: WPS211  # ToDo (tribunsky.kir): reconsider API of 'how'

--- a/wunderkafka/consumers/types.py
+++ b/wunderkafka/consumers/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Optional, TypeVar
 
 from pydantic import Field, BaseModel, ConfigDict, model_validator
 
@@ -14,8 +14,8 @@ class PayloadError(BaseModel):
 
 class StreamResult(BaseModel, Generic[M]):
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    payload: dict[str, Any] | None = None
-    error: PayloadError | None = None
+    payload: Optional[dict[str, Any]] = None
+    error: Optional[PayloadError] = None
     msg: M
     t0: float = Field(default_factory=time.perf_counter)
 

--- a/wunderkafka/consumers/types.py
+++ b/wunderkafka/consumers/types.py
@@ -14,8 +14,8 @@ class PayloadError(BaseModel):
 
 class StreamResult(BaseModel, Generic[M]):
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    payload: Optional[Dict[str, Any]] = None
-    error: Optional[PayloadError] = None
+    payload: dict[str, Any] | None = None
+    error: PayloadError | None = None
     msg: M
     t0: float = Field(default_factory=time.perf_counter)
 

--- a/wunderkafka/consumers/types.py
+++ b/wunderkafka/consumers/types.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import time
-from typing import Generic, Optional, TypeVar, Any, Dict
+from typing import Any, Generic, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import Field, BaseModel, ConfigDict, model_validator
 
 M = TypeVar("M")
 

--- a/wunderkafka/factories/avro.py
+++ b/wunderkafka/factories/avro.py
@@ -28,7 +28,7 @@ class AvroConsumer(HighLevelDeserializingConsumer):
         self,
         config: ConsumerConfig,
         *,
-        sr_client: Optional[Union[Type[ClouderaSRClient], Type[ConfluentSRClient]]] = None,
+        sr_client: Optional[Union[type[ClouderaSRClient], type[ConfluentSRClient]]] = None,
     ) -> None:
         """
         Init consumer from pre-defined blocks.
@@ -47,7 +47,7 @@ class AvroConsumer(HighLevelDeserializingConsumer):
         sr = config.sr
         self._default_timeout: int = 60
         if sr is None:
-            raise ValueError('Schema registry config is necessary for {0}'.format(self.__class__.__name__))
+            raise ValueError(f'Schema registry config is necessary for {self.__class__.__name__}')
         if sr_client is None:
             sr_client = ClouderaSRClient
 
@@ -68,10 +68,10 @@ class AvroProducer(HighLevelSerializingProducer):
 
     def __init__(
         self,
-        mapping: Optional[Dict[TopicName, MessageDescription]],
+        mapping: Optional[dict[TopicName, MessageDescription]],
         config: ProducerConfig,
         *,
-        sr_client: Optional[Union[Type[ClouderaSRClient], Type[ConfluentSRClient]]] = None,
+        sr_client: Optional[Union[type[ClouderaSRClient], type[ConfluentSRClient]]] = None,
         protocol_id: int = 1
     ) -> None:
         """
@@ -93,7 +93,7 @@ class AvroProducer(HighLevelSerializingProducer):
         """
         sr = config.sr
         if sr is None:
-            raise ValueError('Schema registry config is necessary for {0}'.format(self.__class__.__name__))
+            raise ValueError(f'Schema registry config is necessary for {self.__class__.__name__}')
         if sr_client is None:
             sr_client = ClouderaSRClient
         self._default_timeout: int = 60
@@ -118,10 +118,10 @@ class AvroModelProducer(HighLevelSerializingProducer):
 
     def __init__(
         self,
-        mapping: Optional[Dict[TopicName, MessageDescription]],
+        mapping: Optional[dict[TopicName, MessageDescription]],
         config: ProducerConfig,
         *,
-        sr_client: Optional[Union[Type[ClouderaSRClient], Type[ConfluentSRClient]]] = None,
+        sr_client: Optional[Union[type[ClouderaSRClient], type[ConfluentSRClient]]] = None,
         protocol_id: int = 1
     ) -> None:
         """
@@ -144,7 +144,7 @@ class AvroModelProducer(HighLevelSerializingProducer):
         """
         sr = config.sr
         if sr is None:
-            raise ValueError('Schema registry config is necessary for {0}'.format(self.__class__.__name__))
+            raise ValueError(f'Schema registry config is necessary for {self.__class__.__name__}')
 
         if sr_client is None:
             sr_client = ClouderaSRClient
@@ -185,12 +185,12 @@ class AvroClouderaConsumer(AvroConsumer):
 class AvroModelConfluentProducer(AvroModelProducer):
     """Kafka Confluent Producer client to serialize and send models or dataclasses as messages."""
 
-    def __init__(self, mapping: Optional[Dict[TopicName, MessageDescription]], config: ProducerConfig):
+    def __init__(self, mapping: Optional[dict[TopicName, MessageDescription]], config: ProducerConfig):
         super().__init__(mapping, config, sr_client=ConfluentSRClient, protocol_id=0)
 
 
 class AvroModelClouderaProducer(AvroModelProducer):
     """Kafka Cloudera Producer client to serialize and send models or dataclasses as messages."""
 
-    def __init__(self, mapping: Optional[Dict[TopicName, MessageDescription]], config: ProducerConfig):
+    def __init__(self, mapping: Optional[dict[TopicName, MessageDescription]], config: ProducerConfig):
         super().__init__(mapping, config, sr_client=ClouderaSRClient, protocol_id=1)

--- a/wunderkafka/factories/avro.py
+++ b/wunderkafka/factories/avro.py
@@ -1,21 +1,17 @@
 """This module contains some ready-to-go combinations of the Consumer/Producer."""
 
-from typing import Dict, Type, Union, Optional
+from typing import Union, Optional
 
 from wunderkafka import ConsumerConfig, ProducerConfig
-from wunderkafka.config.krb.rdkafka import config_requires_kerberos
-from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
-from wunderkafka.structures import SchemaType
 from wunderkafka.types import TopicName, MessageDescription
-from wunderkafka.serdes.avro import (
-    FastAvroSerializer,
-    AvroModelSerializer,
-    FastAvroDeserializer,
-)
+from wunderkafka.structures import SchemaType
+from wunderkafka.serdes.avro import FastAvroSerializer, AvroModelSerializer, FastAvroDeserializer
 from wunderkafka.serdes.store import AvroModelRepo, SchemaTextRepo
+from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.consumers.bytes import BytesConsumer
 from wunderkafka.producers.bytes import BytesProducer
 from wunderkafka.schema_registry import SimpleCache, ClouderaSRClient, KerberizableHTTPClient
+from wunderkafka.config.krb.rdkafka import config_requires_kerberos
 from wunderkafka.consumers.constructor import HighLevelDeserializingConsumer
 from wunderkafka.producers.constructor import HighLevelSerializingProducer
 from wunderkafka.schema_registry.clients.confluent import ConfluentSRClient

--- a/wunderkafka/factories/json.py
+++ b/wunderkafka/factories/json.py
@@ -26,7 +26,7 @@ class JSONConsumer(HighLevelDeserializingConsumer):
         self,
         config: ConsumerConfig,
         *,
-        sr_client: Optional[Union[Type[ClouderaSRClient], Type[ConfluentSRClient]]] = None,
+        sr_client: Optional[Union[type[ClouderaSRClient], type[ConfluentSRClient]]] = None,
     ) -> None:
         """
         Init consumer from pre-defined blocks.
@@ -45,7 +45,7 @@ class JSONConsumer(HighLevelDeserializingConsumer):
         sr = config.sr
         self._default_timeout: int = 60
         if sr is None:
-            raise ValueError('Schema registry config is necessary for {0}'.format(self.__class__.__name__))
+            raise ValueError(f'Schema registry config is necessary for {self.__class__.__name__}')
         if sr_client is None:
             sr_client = ClouderaSRClient
 
@@ -69,10 +69,10 @@ class JSONProducer(HighLevelSerializingProducer):
 
     def __init__(
         self,
-        mapping: Optional[Dict[TopicName, MessageDescription]],
+        mapping: Optional[dict[TopicName, MessageDescription]],
         config: ProducerConfig,
         *,
-        sr_client: Optional[Type[ConfluentSRClient]] = None,
+        sr_client: Optional[type[ConfluentSRClient]] = None,
         protocol_id: int = 1
     ) -> None:
         """
@@ -94,7 +94,7 @@ class JSONProducer(HighLevelSerializingProducer):
         """
         sr = config.sr
         if sr is None:
-            raise ValueError('Schema registry config is necessary for {0}'.format(self.__class__.__name__))
+            raise ValueError(f'Schema registry config is necessary for {self.__class__.__name__}')
         if sr_client is None:
             sr_client = ConfluentSRClient
         self._default_timeout: int = 60
@@ -121,10 +121,10 @@ class JSONModelProducer(HighLevelSerializingProducer):
 
     def __init__(
         self,
-        mapping: Optional[Dict[TopicName, MessageDescription]],
+        mapping: Optional[dict[TopicName, MessageDescription]],
         config: ProducerConfig,
         *,
-        sr_client: Optional[Type[ConfluentSRClient]] = None,
+        sr_client: Optional[type[ConfluentSRClient]] = None,
         protocol_id: int = 1
     ) -> None:
         """
@@ -147,7 +147,7 @@ class JSONModelProducer(HighLevelSerializingProducer):
         """
         sr = config.sr
         if sr is None:
-            raise ValueError('Schema registry config is necessary for {0}'.format(self.__class__.__name__))
+            raise ValueError(f'Schema registry config is necessary for {self.__class__.__name__}')
 
         if sr_client is None:
             sr_client = ConfluentSRClient
@@ -182,5 +182,5 @@ class JSONConfluentConsumer(JSONConsumer):
 class JSONModelConfluentProducer(JSONModelProducer):
     """Kafka Confluent Producer client to serialize and send models or dataclasses as messages."""
 
-    def __init__(self, mapping: Optional[Dict[TopicName, MessageDescription]], config: ProducerConfig):
+    def __init__(self, mapping: Optional[dict[TopicName, MessageDescription]], config: ProducerConfig):
         super().__init__(mapping, config, sr_client=ConfluentSRClient, protocol_id=0)

--- a/wunderkafka/factories/json.py
+++ b/wunderkafka/factories/json.py
@@ -1,21 +1,21 @@
 """This module contains some ready-to-go combinations of the Consumer/Producer."""
 
-from typing import Dict, Type, Union, Optional
+from typing import Union, Optional
 
 from wunderkafka import ConsumerConfig, ProducerConfig
-from wunderkafka.config.krb.rdkafka import config_requires_kerberos
-from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
-from wunderkafka.serdes.json.deserializers import JSONDeserializer
-from wunderkafka.serdes.json.serializers import JSONSerializer
-from wunderkafka.serdes.jsonmodel.serializers import JSONModelSerializer
-from wunderkafka.structures import SchemaType
 from wunderkafka.types import TopicName, MessageDescription
+from wunderkafka.structures import SchemaType
 from wunderkafka.serdes.store import JSONModelRepo, SchemaTextRepo
+from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.consumers.bytes import BytesConsumer
 from wunderkafka.producers.bytes import BytesProducer
 from wunderkafka.schema_registry import SimpleCache, ClouderaSRClient, KerberizableHTTPClient
+from wunderkafka.config.krb.rdkafka import config_requires_kerberos
 from wunderkafka.consumers.constructor import HighLevelDeserializingConsumer
 from wunderkafka.producers.constructor import HighLevelSerializingProducer
+from wunderkafka.serdes.json.serializers import JSONSerializer
+from wunderkafka.serdes.json.deserializers import JSONDeserializer
+from wunderkafka.serdes.jsonmodel.serializers import JSONModelSerializer
 from wunderkafka.schema_registry.clients.confluent import ConfluentSRClient
 
 

--- a/wunderkafka/factories/mixed.py
+++ b/wunderkafka/factories/mixed.py
@@ -29,7 +29,7 @@ class AvroStringConsumer(HighLevelDeserializingConsumer):
         self,
         config: ConsumerConfig,
         *,
-        sr_client: Optional[Type[ConfluentSRClient]] = None,
+        sr_client: Optional[type[ConfluentSRClient]] = None,
     ) -> None:
         """
         Init consumer from pre-defined blocks.
@@ -48,7 +48,7 @@ class AvroStringConsumer(HighLevelDeserializingConsumer):
         self._default_timeout: int = 60
         sr = config.sr
         if sr is None:
-            raise ValueError("Schema registry config is necessary for {0}".format(self.__class__.__name__))
+            raise ValueError(f"Schema registry config is necessary for {self.__class__.__name__}")
         if sr_client is None:
             sr_client = ConfluentSRClient
 
@@ -70,10 +70,10 @@ class AvroModelStringProducer(HighLevelSerializingProducer):
 
     def __init__(
         self,
-        mapping: Optional[Dict[TopicName, MessageDescription]],
+        mapping: Optional[dict[TopicName, MessageDescription]],
         config: ProducerConfig,
         *,
-        sr_client: Optional[Type[ConfluentSRClient]] = None,
+        sr_client: Optional[type[ConfluentSRClient]] = None,
     ) -> None:
         """
         Init producer from pre-defined blocks.
@@ -95,7 +95,7 @@ class AvroModelStringProducer(HighLevelSerializingProducer):
         self._default_timeout: int = 60
         sr = config.sr
         if sr is None:
-            raise ValueError("Schema registry config is necessary for {0}".format(self.__class__.__name__))
+            raise ValueError(f"Schema registry config is necessary for {self.__class__.__name__}")
 
         if sr_client is None:
             sr_client = ConfluentSRClient
@@ -124,7 +124,7 @@ class JSONStringConsumer(HighLevelDeserializingConsumer):
         self,
         config: ConsumerConfig,
         *,
-        sr_client: Optional[Type[ConfluentSRClient]] = None,
+        sr_client: Optional[type[ConfluentSRClient]] = None,
     ) -> None:
         """
         Init consumer from pre-defined blocks.
@@ -143,7 +143,7 @@ class JSONStringConsumer(HighLevelDeserializingConsumer):
         self._default_timeout: int = 60
         sr = config.sr
         if sr is None:
-            raise ValueError("Schema registry config is necessary for {0}".format(self.__class__.__name__))
+            raise ValueError(f"Schema registry config is necessary for {self.__class__.__name__}")
         if sr_client is None:
             sr_client = ConfluentSRClient
 
@@ -165,10 +165,10 @@ class JSONModelStringProducer(HighLevelSerializingProducer):
 
     def __init__(
         self,
-        mapping: Optional[Dict[TopicName, MessageDescription]],
+        mapping: Optional[dict[TopicName, MessageDescription]],
         config: ProducerConfig,
         *,
-        sr_client: Optional[Type[ConfluentSRClient]] = None,
+        sr_client: Optional[type[ConfluentSRClient]] = None,
     ) -> None:
         """
         Init producer from pre-defined blocks.
@@ -191,7 +191,7 @@ class JSONModelStringProducer(HighLevelSerializingProducer):
 
         sr = config.sr
         if sr is None:
-            raise ValueError("Schema registry config is necessary for {0}".format(self.__class__.__name__))
+            raise ValueError(f"Schema registry config is necessary for {self.__class__.__name__}")
 
         if sr_client is None:
             sr_client = ConfluentSRClient

--- a/wunderkafka/factories/mixed.py
+++ b/wunderkafka/factories/mixed.py
@@ -1,25 +1,21 @@
 """This module contains some ready-to-go combinations of the Consumer/Producer."""
 
-from typing import Type, Optional, Dict
+from typing import Optional
 
 from wunderkafka import BytesConsumer, BytesProducer, ConsumerConfig, ProducerConfig
+from wunderkafka.types import TopicName, MessageDescription
+from wunderkafka.serdes.avro import FastAvroDeserializer
+from wunderkafka.serdes.store import AvroModelRepo
+from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
+from wunderkafka.schema_registry import SimpleCache, ConfluentSRClient, KerberizableHTTPClient
 from wunderkafka.config.krb.rdkafka import config_requires_kerberos
 from wunderkafka.consumers.constructor import HighLevelDeserializingConsumer
 from wunderkafka.producers.constructor import HighLevelSerializingProducer
-from wunderkafka.schema_registry import (
-    ConfluentSRClient,
-    KerberizableHTTPClient,
-    SimpleCache,
-)
-from wunderkafka.serdes.avro import FastAvroDeserializer
-from wunderkafka.serdes.avromodel.serializers import AvroModelSerializer
-from wunderkafka.serdes.headers import ConfluentClouderaHeadersHandler
 from wunderkafka.serdes.json.deserializers import JSONDeserializer
+from wunderkafka.serdes.avromodel.serializers import AvroModelSerializer
 from wunderkafka.serdes.jsonmodel.serializers import JSONModelSerializer
-from wunderkafka.serdes.schemaless.string.deserializers import StringDeserializer
 from wunderkafka.serdes.schemaless.string.serializers import StringSerializer
-from wunderkafka.serdes.store import AvroModelRepo
-from wunderkafka.types import MessageDescription, TopicName
+from wunderkafka.serdes.schemaless.string.deserializers import StringDeserializer
 
 
 class AvroStringConsumer(HighLevelDeserializingConsumer):

--- a/wunderkafka/factories/schemaless.py
+++ b/wunderkafka/factories/schemaless.py
@@ -16,7 +16,7 @@ class SchemaLessJSONStringProducer(HighLevelSerializingProducer):
 
     def __init__(
         self,
-        mapping: Optional[Dict[TopicName, MessageDescription]],
+        mapping: Optional[dict[TopicName, MessageDescription]],
         config: ProducerConfig,
     ) -> None:
         """
@@ -46,7 +46,7 @@ class SchemaLessJSONModelStringProducer(HighLevelSerializingProducer):
 
     def __init__(
         self,
-        mapping: Optional[Dict[TopicName, MessageDescription]],
+        mapping: Optional[dict[TopicName, MessageDescription]],
         config: ProducerConfig,
     ) -> None:
         """

--- a/wunderkafka/factories/schemaless.py
+++ b/wunderkafka/factories/schemaless.py
@@ -1,14 +1,14 @@
-from typing import Optional, Dict
+from typing import Optional
 
-from wunderkafka import ProducerConfig, BytesProducer, ConsumerConfig, BytesConsumer
+from wunderkafka import BytesConsumer, BytesProducer, ConsumerConfig, ProducerConfig
+from wunderkafka.types import TopicName, MessageDescription
 from wunderkafka.consumers.constructor import HighLevelDeserializingConsumer
 from wunderkafka.producers.constructor import HighLevelSerializingProducer
-from wunderkafka.serdes.schemaless.json.deserializers import SchemaLessJSONDeserializer
 from wunderkafka.serdes.schemaless.json.serializers import SchemaLessJSONSerializer
-from wunderkafka.serdes.schemaless.jsonmodel.serializers import SchemaLessJSONModelSerializer
-from wunderkafka.serdes.schemaless.string.deserializers import StringDeserializer
+from wunderkafka.serdes.schemaless.json.deserializers import SchemaLessJSONDeserializer
 from wunderkafka.serdes.schemaless.string.serializers import StringSerializer
-from wunderkafka.types import TopicName, MessageDescription
+from wunderkafka.serdes.schemaless.string.deserializers import StringDeserializer
+from wunderkafka.serdes.schemaless.jsonmodel.serializers import SchemaLessJSONModelSerializer
 
 
 class SchemaLessJSONStringProducer(HighLevelSerializingProducer):

--- a/wunderkafka/hotfixes/watchdog/__init__.py
+++ b/wunderkafka/hotfixes/watchdog/__init__.py
@@ -14,10 +14,10 @@ from wunderkafka.hotfixes.watchdog.types import Watchdog
 REQUIRES_KERBEROS = frozenset([enums.SecurityProtocol.sasl_ssl, enums.SecurityProtocol.sasl_plaintext])
 
 
-class NonRepetitiveLogger(object):
+class NonRepetitiveLogger:
 
     def __init__(self) -> None:
-        self._logged: Set[int] = set()
+        self._logged: set[int] = set()
 
     def _log(self, message: str, *, info: bool = True) -> None:
         hashed = hash(message)
@@ -40,7 +40,7 @@ log_once = NonRepetitiveLogger()
 
 
 @dataclass(frozen=True)
-class KinitParams(object):
+class KinitParams:
     user: str
     realm: str
     keytab: str
@@ -52,27 +52,27 @@ class KinitParams(object):
 
     @property
     def principal(self) -> str:
-        return '{0}@{1}'.format(self.user, self.realm)
+        return f'{self.user}@{self.realm}'
 
 
-def get_version() -> Tuple[int, ...]:
+def get_version() -> tuple[int, ...]:
     semver, _ = libversion()
     return split(semver)
 
 
-def split(version: str) -> Tuple[int, ...]:
+def split(version: str) -> tuple[int, ...]:
     return tuple(int(digit) for digit in version.split('.')[:2])
 
 
-class Borg(object):
-    _shared_state: Dict[str, Any] = {}
+class Borg:
+    _shared_state: dict[str, Any] = {}
 
     def __init__(self) -> None:
         self.__dict__ = self._shared_state
 
 
 def parse_kinit(kinit_cmd: str) -> KinitParams:
-    kinit_cmd_msg = 'kinit_cmd: `{0}`'.format(kinit_cmd)
+    kinit_cmd_msg = f'kinit_cmd: `{kinit_cmd}`'
     parts = []
     keytab = None
     prev = None
@@ -84,14 +84,14 @@ def parse_kinit(kinit_cmd: str) -> KinitParams:
             parts.append(normalized)
         prev = normalized
     if keytab is None:
-        raise ValueError("Couldn't get keytab: {0} ({1})".format(keytab, kinit_cmd_msg))
+        raise ValueError(f"Couldn't get keytab: {keytab} ({kinit_cmd_msg})")
     if len(parts) != 1:
-        raise ValueError("Couldn't parse {0}".format(kinit_cmd_msg))
+        raise ValueError(f"Couldn't parse {kinit_cmd_msg}")
     [principal] = parts
     delim = '@'
     user, realm = principal.split(delim)
     if not (user and realm):
-        raise ValueError("Couldn't parse principal: {0} ({1})".format(principal, kinit_cmd_msg))
+        raise ValueError(f"Couldn't parse principal: {principal} ({kinit_cmd_msg})")
     return KinitParams(user=user, realm=realm, keytab=keytab, cmd=kinit_cmd)
 
 
@@ -99,7 +99,7 @@ def parse_kinit(kinit_cmd: str) -> KinitParams:
 def init_kerberos(params: KinitParams, timeout: int = 60) -> None:
     t0 = time.perf_counter()
     refresh_cmd = params.cmd.split()
-    logger.info('Refreshing krb-ticket ({0}|{1})...'.format(params.principal, params.keytab_filename))
+    logger.info(f'Refreshing krb-ticket ({params.principal}|{params.keytab_filename})...')
     try:
         subprocess.run(refresh_cmd, timeout=timeout, stdout=subprocess.PIPE, check=True)
     # Will retry shortly
@@ -107,9 +107,9 @@ def init_kerberos(params: KinitParams, timeout: int = 60) -> None:
         logger.error(exc.output)
         logger.error(exc.stdout)
         logger.error(exc.stderr)
-        logger.error('Command: {0} exit error: {1}'.format(refresh_cmd, str(exc)))
+        logger.error(f'Command: {refresh_cmd} exit error: {str(exc)}')
         logger.warning("Krb not refreshed!")
     else:
         duration = int(1000 * (time.perf_counter() - t0))
-        logger.info('Refreshed! ({0} ms)'.format(duration))
+        logger.info(f'Refreshed! ({duration} ms)')
 

--- a/wunderkafka/hotfixes/watchdog/__init__.py
+++ b/wunderkafka/hotfixes/watchdog/__init__.py
@@ -1,7 +1,7 @@
 import os
 import time
 import subprocess
-from typing import Any, Set, Dict, Tuple, Optional
+from typing import Any
 from dataclasses import dataclass
 
 from confluent_kafka import libversion
@@ -12,6 +12,12 @@ from wunderkafka.config.generated import enums
 from wunderkafka.hotfixes.watchdog.types import Watchdog
 
 REQUIRES_KERBEROS = frozenset([enums.SecurityProtocol.sasl_ssl, enums.SecurityProtocol.sasl_plaintext])
+
+
+__all__ = [
+    'Watchdog',
+    'RDKafkaConfig',
+]
 
 
 class NonRepetitiveLogger:

--- a/wunderkafka/hotfixes/watchdog/krb/ticket.py
+++ b/wunderkafka/hotfixes/watchdog/krb/ticket.py
@@ -2,7 +2,7 @@ import os
 import time
 import datetime
 import subprocess
-from typing import Set, Optional
+from typing import Optional
 
 try:
     from dateutil import parser

--- a/wunderkafka/hotfixes/watchdog/krb/ticket.py
+++ b/wunderkafka/hotfixes/watchdog/krb/ticket.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import time
 import datetime
@@ -49,28 +47,28 @@ def check_posix() -> None:
         logger.error(exc.output)
         logger.error(exc.stdout)
         logger.error(exc.stderr)
-        logger.error('locale exit code: {0}'.format(exc.returncode))
+        logger.error(f'locale exit code: {exc.returncode}')
     else:
         lines = {line.strip() for line in proc.stdout.split(b'\n')}
         if b'POSIX' in lines:
             logger.debug('POSIX locale found.')
             return
         if b'posix' in {line.lower() for line in lines}:
-            logger.warning('Found POSIX, but in lower-case. Please, check `locale -a` ({0})'.format(lines))
+            logger.warning(f'Found POSIX, but in lower-case. Please, check `locale -a` ({lines})')
             return
         logger.warning("Couldn't find any POSIX in locales. May misbehave.")
 
 
-def clean_stdout(stdout: str, krb_user: str = '', krb_realm: str = '') -> Set[str]:
+def clean_stdout(stdout: str, krb_user: str = '', krb_realm: str = '') -> set[str]:
     date_lines = set()
     for line in stdout.split('\n'):
         if krb_realm in line and krb_user not in line:
             _, _, dt, tm, *_ = line.split()
-            date_lines.add('{0} {1}'.format(dt, tm))
+            date_lines.add(f'{dt} {tm}')
 
     if not date_lines:
-        raise ValueError('Found no expiration dates. Please, check stdout:\n{0}'.format(stdout))
-    logger.debug('Got {0} expiration dates'.format(len(date_lines)))
+        raise ValueError(f'Found no expiration dates. Please, check stdout:\n{stdout}')
+    logger.debug(f'Got {len(date_lines)} expiration dates')
     return date_lines
 
 
@@ -93,7 +91,7 @@ def get_expiration_ts(krb_user: str, krb_realm: str, default_timeout: float = 60
         logger.error(exc.output)
         logger.error(exc.stdout)
         logger.error(exc.stderr)
-        logger.error('klist exit: {0}'.format(str(exc)))
+        logger.error(f'klist exit: {str(exc)}')
         return time.time() + default_timeout
     else:
         expire_dates = []
@@ -101,7 +99,7 @@ def get_expiration_ts(krb_user: str, krb_realm: str, default_timeout: float = 60
             dt = get_datetime(dt_str)
             if dt is not None:
                 expire_dates.append(dt)
-        logger.debug('Parsed dates: {0}'.format(expire_dates))
+        logger.debug(f'Parsed dates: {expire_dates}')
         if not expire_dates:
             logger.warning('Got not expiration dates')
             return time.time() + default_timeout
@@ -119,5 +117,5 @@ def get_datetime(string: str) -> Optional[datetime.datetime]:
     try:
         return parser.parse(string)
     except (ValueError, OverflowError):
-        logger.warning('Unable to parse {0}'.format(string))
+        logger.warning(f'Unable to parse {string}')
     return None

--- a/wunderkafka/producers/bytes.py
+++ b/wunderkafka/producers/bytes.py
@@ -5,11 +5,11 @@ from typing import Any, Union, Optional
 
 from confluent_kafka import KafkaException
 
-from wunderkafka.config.krb.rdkafka import challenge_krb_arg
 from wunderkafka.types import DeliveryCallback
 from wunderkafka.config import ProducerConfig
 from wunderkafka.callbacks import error_callback
 from wunderkafka.producers.abc import AbstractProducer
+from wunderkafka.config.krb.rdkafka import challenge_krb_arg
 
 
 class BytesProducer(AbstractProducer):

--- a/wunderkafka/producers/constructor.py
+++ b/wunderkafka/producers/constructor.py
@@ -32,7 +32,7 @@ class HighLevelSerializingProducer(AbstractSerializingProducer):
         serializer: Optional[AbstractSerializer] = None,
         store: Optional[AbstractDescriptionStore] = None,
         # ToDo: switch mapping to something like consumer's TopicSubscription?
-        mapping: Optional[Dict[TopicName, MessageDescription]] = None,
+        mapping: Optional[dict[TopicName, MessageDescription]] = None,
         value_serializer: Optional[AbstractSerializer] = None,
         key_serializer: Optional[AbstractSerializer] = None,
         *,
@@ -60,7 +60,7 @@ class HighLevelSerializingProducer(AbstractSerializingProducer):
 
         # ToDo (tribunsky.kir): look like wrong place. Maybe it's better to highlight an entity
         #                       of Schema which may be checked or not. Then input mapping may be eliminated (or not).
-        self._checked: Dict[Tuple[str, str, bool], SRMeta] = {}
+        self._checked: dict[tuple[str, str, bool], SRMeta] = {}
 
         self._store = store
         self._sr = schema_registry
@@ -167,7 +167,7 @@ class HighLevelSerializingProducer(AbstractSerializingProducer):
         :return:        Container with schema's ids.
         """
         if self._sr is None:
-            logger.warning('Schema registry is not passed, skipping schema check for {0}'.format(topic))
+            logger.warning(f'Schema registry is not passed, skipping schema check for {topic}')
             return None
         if schema is None:
             raise ValueError("Couldn't check schema from store.")
@@ -194,7 +194,7 @@ class HighLevelSerializingProducer(AbstractSerializingProducer):
 
         schema = store.get(topic, is_key=is_key)
         if schema is None:
-            logger.warning('Missing schema for {0} (key: {1}'.format(topic, is_key))
+            logger.warning(f'Missing schema for {topic} (key: {is_key}')
             return None
         if schema.empty:
             return serializer.serialize(schema.text, obj, None, topic, is_key=is_key)

--- a/wunderkafka/producers/constructor.py
+++ b/wunderkafka/producers/constructor.py
@@ -7,7 +7,7 @@ All moving parts should be interchangeable in terms of schema, header and serial
 (for further overriding^W extending).
 """
 
-from typing import Any, Dict, Tuple, Optional
+from typing import Any, Optional
 
 from wunderkafka.types import MsgKey, MsgValue, TopicName, HeaderPacker, DeliveryCallback, MessageDescription
 from wunderkafka.logger import logger

--- a/wunderkafka/protocols.py
+++ b/wunderkafka/protocols.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, List, Union, Optional
+from typing import Any, Union, Optional
 
 from confluent_kafka import Message, TopicPartition
 from typing_extensions import Protocol

--- a/wunderkafka/protocols.py
+++ b/wunderkafka/protocols.py
@@ -19,14 +19,14 @@ class AnyConsumer(Protocol):
     def commit(
         self,
         message: Optional[Message] = None,
-        offsets: Optional[List[TopicPartition]] = None,
+        offsets: Optional[list[TopicPartition]] = None,
         asynchronous: bool = True,
-    ) -> Optional[List[TopicPartition]]:
+    ) -> Optional[list[TopicPartition]]:
         """Just overlap nested 'real' consumer's offset."""
 
     def subscribe(
         self,
-        topics: List[Union[str, TopicSubscription]],
+        topics: list[Union[str, TopicSubscription]],
         *,
         from_beginning: Optional[bool] = None,
         offset: Optional[int] = None,
@@ -42,7 +42,7 @@ class AnyConsumer(Protocol):
         num_messages: int = 1000000,
         *,
         ignore_keys: bool = False,
-    ) -> List[Message]:
+    ) -> list[Message]:
         """Consume as many messages as we can for a given timeout and decode them."""
 
 

--- a/wunderkafka/schema_registry/__init__.py
+++ b/wunderkafka/schema_registry/__init__.py
@@ -2,3 +2,11 @@ from wunderkafka.schema_registry.cache import SimpleCache
 from wunderkafka.schema_registry.transport import KerberizableHTTPClient
 from wunderkafka.schema_registry.clients.cloudera import ClouderaSRClient
 from wunderkafka.schema_registry.clients.confluent import ConfluentSRClient
+
+
+__all__ = [
+    'SimpleCache',
+    'KerberizableHTTPClient',
+    'ClouderaSRClient',
+    'ConfluentSRClient',
+]

--- a/wunderkafka/schema_registry/cache.py
+++ b/wunderkafka/schema_registry/cache.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 
 class SimpleCache:

--- a/wunderkafka/schema_registry/cache.py
+++ b/wunderkafka/schema_registry/cache.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict
 
 
-class SimpleCache(object):
+class SimpleCache:
     def __init__(self) -> None:
-        self._store: Dict[Any, Any] = {}
+        self._store: dict[Any, Any] = {}
 
     def get(self, key: Any) -> Any:
         return self._store.get(key)

--- a/wunderkafka/schema_registry/clients/cloudera.py
+++ b/wunderkafka/schema_registry/clients/cloudera.py
@@ -9,19 +9,19 @@ from wunderkafka.schema_registry.cache import SimpleCache, AlwaysEmptyCache
 
 
 def prepare_schemas_for_caching(
-    versions: Dict[str, List[Dict[str, Optional[Union[int, str]]]]],
-) -> Dict[ParsedHeader, str]:
+    versions: dict[str, list[dict[str, Optional[Union[int, str]]]]],
+) -> dict[ParsedHeader, str]:
     schemas_to_header_mapping = {}
     for schema in versions['entities']:
         txt = schema['schemaText']
         if not isinstance(txt, str):
-            raise ValueError('Provided SchemaText is not str: {0}'.format(schema))
+            raise ValueError(f'Provided SchemaText is not str: {schema}')
         meta_id = schema['schemaMetadataId']
         if not isinstance(meta_id, int):
-            raise ValueError('Wrong schemaMetadataId (not int): {0}'.format(schema))
+            raise ValueError(f'Wrong schemaMetadataId (not int): {schema}')
         schema_version = schema['version']
         if not isinstance(schema_version, int):
-            raise ValueError('Wrong schema version (not int): {0}'.format(schema))
+            raise ValueError(f'Wrong schema version (not int): {schema}')
         new_header_v1 = ParsedHeader(
             protocol_id=1,
             meta_id=meta_id,
@@ -31,7 +31,7 @@ def prepare_schemas_for_caching(
         )
         schema_id = schema['id']
         if not isinstance(schema_id, int):
-            raise ValueError('Wrong schema id (not int): {0}'.format(schema))
+            raise ValueError(f'Wrong schema id (not int): {schema}')
         new_header_v2 = ParsedHeader(
             protocol_id=2,
             meta_id=None,
@@ -63,7 +63,7 @@ class ClouderaSRClient(AbstractSchemaRegistry):
         return self._requests_count
 
     def _send_request_for_schema(self, meta: SchemaMeta) -> Any:
-        versions = self._client.make_request('schemas/{0}/versions'.format(meta.subject))
+        versions = self._client.make_request(f'schemas/{meta.subject}/versions')
         self._requests_count += 1
         return versions
 
@@ -86,7 +86,7 @@ class ClouderaSRClient(AbstractSchemaRegistry):
             "schemaText": schema_text,
         }
         query = {'branch': 'MASTER'}
-        return self._client.make_request('schemas/{0}/versions'.format(subject), method='POST', body=body, query=query)
+        return self._client.make_request(f'schemas/{subject}/versions', method='POST', body=body, query=query)
 
     def get_schema_text(self, meta: SchemaMeta) -> str:
         # ToDo (tribunsky.kir): arguably, the best key is BINARY header, not dataclass.
@@ -95,16 +95,16 @@ class ClouderaSRClient(AbstractSchemaRegistry):
         schema_text = self._cache.get(meta.header)
         if schema_text is not None:
             return schema_text
-        logger.debug("Couldn't find header ({0}) in cache, re-requesting...".format(meta.header))
+        logger.debug(f"Couldn't find header ({meta.header}) in cache, re-requesting...")
         versions = self._send_request_for_schema(meta)
         for hdr, txt in prepare_schemas_for_caching(versions).items():
             self._cache.set(hdr, txt)
         schema_text = self._cache.get(meta.header)
         if schema_text is None:
-            error_message = "Couldn't find schema for {0}".format(meta.header)
+            error_message = f"Couldn't find schema for {meta.header}"
             logger.error(error_message)
             for schema in versions['entities']:
-                logger.warning('\tschema: {0}'.format(schema))
+                logger.warning(f'\tschema: {schema}')
             raise SchemaRegistryLookupException(error_message)
         return schema_text
 
@@ -116,12 +116,12 @@ class ClouderaSRClient(AbstractSchemaRegistry):
         meta = self._cache.get(uid)
         if meta is None:
             suffix = ':k' if is_key else ''
-            subject = '{0}{1}'.format(topic, suffix)
+            subject = f'{topic}{suffix}'
             # ToDo (tribunsky.kir): three queries is bad. Either we should know protocol id,
             #                       e.g. to skip last query (we do not need id always)
             meta_id = self._create_meta(subject)
             schema_version = self._create_schema(subject, schema_text)
-            versions = self._client.make_request('schemas/{0}/versions'.format(subject))
+            versions = self._client.make_request(f'schemas/{subject}/versions')
             for mt in versions['entities']:
                 if mt['schemaMetadataId'] == meta_id and mt['version'] == schema_version:
                     meta = SRMeta(

--- a/wunderkafka/schema_registry/clients/cloudera.py
+++ b/wunderkafka/schema_registry/clients/cloudera.py
@@ -1,10 +1,10 @@
-from typing import Any, Dict, List, Union, Optional
+from typing import Any, Union, Optional
 
 from wunderkafka.errors import SchemaRegistryLookupException
 from wunderkafka.logger import logger
-from wunderkafka.structures import SRMeta, SchemaMeta, ParsedHeader, SchemaType
-from wunderkafka.schema_registry.abc import AbstractHTTPClient, AbstractSchemaRegistry
+from wunderkafka.structures import SRMeta, SchemaMeta, SchemaType, ParsedHeader
 from wunderkafka.serdes.headers import PROTOCOLS
+from wunderkafka.schema_registry.abc import AbstractHTTPClient, AbstractSchemaRegistry
 from wunderkafka.schema_registry.cache import SimpleCache, AlwaysEmptyCache
 
 

--- a/wunderkafka/schema_registry/clients/confluent.py
+++ b/wunderkafka/schema_registry/clients/confluent.py
@@ -14,42 +14,42 @@ P = ParamSpec('P')
 
 class ConfluentRestClient(Protocol):
 
-    def get(self, url: str, query: Optional[dict] = None) -> Any:
+    def get(self, url: str, query: dict | None = None) -> Any:
         ...
 
-    def post(self, url: str, body: Optional[str], **kwargs: Any) -> Any:
+    def post(self, url: str, body: str | None, **kwargs: Any) -> Any:
         ...
 
     def delete(self, url: str) -> Any:
         ...
 
-    def put(self, url: str, body: Optional[str] = None) -> Any:
+    def put(self, url: str, body: str | None = None) -> Any:
         ...
 
-    def send_request(self, url: str, method: str, body: Optional[str] = None, query: Optional[dict] = None) -> Any:
+    def send_request(self, url: str, method: str, body: str | None = None, query: dict | None = None) -> Any:
         ...
 
     def _close(self) -> None:
         ...
 
 
-class Adapter(object):
+class Adapter:
     def __init__(self, http_client: AbstractHTTPClient) -> None:
         self._client = http_client
 
-    def get(self, url: str, query: Optional[dict] = None) -> Any:
+    def get(self, url: str, query: dict | None = None) -> Any:
         return self._client.make_request(url, query=query)
 
-    def post(self, url: str, body: Optional[str], **_: Any) -> Any:
+    def post(self, url: str, body: str | None, **_: Any) -> Any:
         return self._client.make_request(url, method='POST', body=body)
 
     def delete(self, url: str) -> Any:
         return self._client.make_request(url, method='DELETE')
 
-    def put(self, url: str, body: Optional[str] = None) -> Any:
+    def put(self, url: str, body: str | None = None) -> Any:
         return self._client.make_request(url, method='PUT', body=body)
 
-    def send_request(self, url: str, method: str, body: Optional[str] = None, query: Optional[dict] = None) -> Any:
+    def send_request(self, url: str, method: str, body: str | None = None, query: dict | None = None) -> Any:
         return self._client.make_request(url, method, body=body, query=query)
 
     def _close(self) -> None:
@@ -71,7 +71,7 @@ class ConfluentSRClient(AbstractSchemaRegistry):
     def __init__(
         self,
         http_client: AbstractHTTPClient,
-        _: Optional[SimpleCache] = None,
+        _: SimpleCache | None = None,
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> None:
@@ -83,6 +83,6 @@ class ConfluentSRClient(AbstractSchemaRegistry):
 
     def register_schema(self, topic: str, schema_text: str, schema_type: SchemaType, *, is_key: bool = True) -> SRMeta:
         # FixMe (tribunsky.kir): lack of symmetry here - SchemaMeta knows about different vendors, but not vice versa.
-        subject = '{0}-{1}'.format(topic, 'key' if is_key else 'value')
+        subject = '{}-{}'.format(topic, 'key' if is_key else 'value')
         schema_id = self.client.register_schema(subject, Schema(schema_text, schema_type=schema_type))
         return SRMeta(schema_id, schema_version=None)

--- a/wunderkafka/schema_registry/clients/confluent.py
+++ b/wunderkafka/schema_registry/clients/confluent.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from typing import Any, Optional
-from typing_extensions import Protocol
-from confluent_kafka.schema_registry import SchemaRegistryClient as ConfluentSchemaRegistryClient, Schema
+from typing import Any
 
-from wunderkafka.schema_registry import SimpleCache
-from wunderkafka.structures import SRMeta, SchemaMeta, SchemaType
-from wunderkafka.schema_registry.abc import AbstractHTTPClient, AbstractSchemaRegistry
+from typing_extensions import Protocol
+from confluent_kafka.schema_registry import Schema
+from confluent_kafka.schema_registry import SchemaRegistryClient as ConfluentSchemaRegistryClient
+
 from wunderkafka.compat import ParamSpec
+from wunderkafka.structures import SRMeta, SchemaMeta, SchemaType
+from wunderkafka.schema_registry import SimpleCache
+from wunderkafka.schema_registry.abc import AbstractHTTPClient, AbstractSchemaRegistry
 
 P = ParamSpec('P')
 

--- a/wunderkafka/schema_registry/clients/confluent.py
+++ b/wunderkafka/schema_registry/clients/confluent.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 from typing_extensions import Protocol
 from confluent_kafka.schema_registry import Schema
@@ -16,19 +16,19 @@ P = ParamSpec('P')
 
 class ConfluentRestClient(Protocol):
 
-    def get(self, url: str, query: dict | None = None) -> Any:
+    def get(self, url: str, query: Optional[dict] = None) -> Any:
         ...
 
-    def post(self, url: str, body: str | None, **kwargs: Any) -> Any:
+    def post(self, url: str, body: Optional[str], **kwargs: Any) -> Any:
         ...
 
     def delete(self, url: str) -> Any:
         ...
 
-    def put(self, url: str, body: str | None = None) -> Any:
+    def put(self, url: str, body: Optional[str]= None) -> Any:
         ...
 
-    def send_request(self, url: str, method: str, body: str | None = None, query: dict | None = None) -> Any:
+    def send_request(self, url: str, method: str, body: Optional[str] = None, query: Optional[dict]= None) -> Any:
         ...
 
     def _close(self) -> None:
@@ -39,19 +39,19 @@ class Adapter:
     def __init__(self, http_client: AbstractHTTPClient) -> None:
         self._client = http_client
 
-    def get(self, url: str, query: dict | None = None) -> Any:
+    def get(self, url: str, query: Optional[dict] = None) -> Any:
         return self._client.make_request(url, query=query)
 
-    def post(self, url: str, body: str | None, **_: Any) -> Any:
+    def post(self, url: str, body: Optional[str], **_: Any) -> Any:
         return self._client.make_request(url, method='POST', body=body)
 
     def delete(self, url: str) -> Any:
         return self._client.make_request(url, method='DELETE')
 
-    def put(self, url: str, body: str | None = None) -> Any:
+    def put(self, url: str, body: Optional[str]= None) -> Any:
         return self._client.make_request(url, method='PUT', body=body)
 
-    def send_request(self, url: str, method: str, body: str | None = None, query: dict | None = None) -> Any:
+    def send_request(self, url: str, method: str, body: Optional[str] = None, query: Optional[dict] = None) -> Any:
         return self._client.make_request(url, method, body=body, query=query)
 
     def _close(self) -> None:
@@ -73,7 +73,7 @@ class ConfluentSRClient(AbstractSchemaRegistry):
     def __init__(
         self,
         http_client: AbstractHTTPClient,
-        _: SimpleCache | None = None,
+        _: Optional[SimpleCache] = None,
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> None:

--- a/wunderkafka/schema_registry/transport.py
+++ b/wunderkafka/schema_registry/transport.py
@@ -4,11 +4,11 @@ from typing import Any, Optional
 
 import requests
 
-from wunderkafka.config.krb.schema_registry import HTTPKerberosAuth
-from wunderkafka.hotfixes.watchdog import init_kerberos, parse_kinit
 from wunderkafka.logger import logger
+from wunderkafka.hotfixes.watchdog import parse_kinit, init_kerberos
 from wunderkafka.schema_registry.abc import AbstractHTTPClient
 from wunderkafka.config.schema_registry import SRConfig
+from wunderkafka.config.krb.schema_registry import HTTPKerberosAuth
 
 
 class KerberizableHTTPClient(AbstractHTTPClient):

--- a/wunderkafka/schema_registry/transport.py
+++ b/wunderkafka/schema_registry/transport.py
@@ -70,7 +70,7 @@ class KerberizableHTTPClient(AbstractHTTPClient):
         query: Any = None,
     ) -> Any:
         url = "/".join([self._base_url.rstrip('/'), relative_url.lstrip('/')])
-        logger.debug('{0}: {1}'.format(method, url))
+        logger.debug(f'{method}: {url}')
         response = self._session.request(method, url, json=body, params=query)
         # ToDo(aa.perelygin): more informative message when fail
         if response.status_code >= 400:
@@ -83,7 +83,7 @@ class KerberizableHTTPClient(AbstractHTTPClient):
 
     def _dump(self, method: str, relative_url: str, response: requests.Response) -> None:
         if self._save_replay:
-            filename = '{0}/{1}.json'.format(method, relative_url)
+            filename = f'{method}/{relative_url}.json'
             dir_name = os.path.dirname(filename)
             os.makedirs(dir_name, exist_ok=True)
             with open(filename, 'w') as fl:

--- a/wunderkafka/serdes/abc.py
+++ b/wunderkafka/serdes/abc.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Union, Optional
+from typing import Any, Union, Optional
 
 from wunderkafka.types import TopicName, KeySchemaDescription, ValueSchemaDescription
 from wunderkafka.structures import SRMeta, ParsedHeader
@@ -22,7 +22,7 @@ class AbstractDeserializer(ABC):
     schemaless: bool = False
 
     @abstractmethod
-    def deserialize(self, schema: str, payload: bytes, seek_pos: int | None = None) -> Any: ...
+    def deserialize(self, schema: str, payload: bytes, seek_pos: Optional[int] = None) -> Any: ...
 
 
 class AbstractSerializer(ABC):
@@ -33,17 +33,17 @@ class AbstractSerializer(ABC):
     # but if serializer has its own store, it will be used instead.
     # Moreover, as for every serializer store may be passed manually,
     # it may be the same object or different if there is such a need.
-    store: AbstractDescriptionStore | None = None
+    store: Optional[AbstractDescriptionStore] = None
 
     @abstractmethod
     def serialize(
         self,
         schema: str,
         payload: Any,
-        header: bytes | None = None,
-        topic: str | None = None,
+        header: Optional[bytes] = None,
+        topic: Optional[str] = None,
         *,
-        is_key: bool | None = None,
+        is_key: Optional[bool] = None,
     ) -> bytes:
         ...
 
@@ -59,7 +59,7 @@ class AbstractDescriptionStore(ABC):
         topic: TopicName,
         *,
         is_key: bool = False,
-    ) -> ValueSchemaDescription | KeySchemaDescription | None:
+    ) -> Optional[Union[ValueSchemaDescription, KeySchemaDescription]]:
         if is_key:
             return self._keys.get(topic)
         else:

--- a/wunderkafka/serdes/abc.py
+++ b/wunderkafka/serdes/abc.py
@@ -22,7 +22,7 @@ class AbstractDeserializer(ABC):
     schemaless: bool = False
 
     @abstractmethod
-    def deserialize(self, schema: str, payload: bytes, seek_pos: Optional[int] = None) -> Any: ...
+    def deserialize(self, schema: str, payload: bytes, seek_pos: int | None = None) -> Any: ...
 
 
 class AbstractSerializer(ABC):
@@ -33,17 +33,17 @@ class AbstractSerializer(ABC):
     # but if serializer has its own store, it will be used instead.
     # Moreover, as for every serializer store may be passed manually,
     # it may be the same object or different if there is such a need.
-    store: Optional[AbstractDescriptionStore] = None
+    store: AbstractDescriptionStore | None = None
 
     @abstractmethod
     def serialize(
         self,
         schema: str,
         payload: Any,
-        header: Optional[bytes] = None,
-        topic: Optional[str] = None,
+        header: bytes | None = None,
+        topic: str | None = None,
         *,
-        is_key: Optional[bool] = None,
+        is_key: bool | None = None,
     ) -> bytes:
         ...
 
@@ -51,15 +51,15 @@ class AbstractSerializer(ABC):
 class AbstractDescriptionStore(ABC):
 
     def __init__(self) -> None:
-        self._values: Dict[TopicName, ValueSchemaDescription] = {}
-        self._keys: Dict[TopicName, KeySchemaDescription] = {}
+        self._values: dict[TopicName, ValueSchemaDescription] = {}
+        self._keys: dict[TopicName, KeySchemaDescription] = {}
 
     def get(
         self,
         topic: TopicName,
         *,
         is_key: bool = False,
-    ) -> Optional[Union[ValueSchemaDescription, KeySchemaDescription]]:
+    ) -> ValueSchemaDescription | KeySchemaDescription | None:
         if is_key:
             return self._keys.get(topic)
         else:

--- a/wunderkafka/serdes/avro/__init__.py
+++ b/wunderkafka/serdes/avro/__init__.py
@@ -1,3 +1,10 @@
 from wunderkafka.serdes.avro.serializers import FastAvroSerializer
 from wunderkafka.serdes.avro.deserializers import FastAvroDeserializer
 from wunderkafka.serdes.avromodel.serializers import AvroModelSerializer
+
+
+__all__ = [
+    'FastAvroSerializer',
+    'FastAvroDeserializer',
+    'AvroModelSerializer',
+]

--- a/wunderkafka/serdes/avro/deserializers.py
+++ b/wunderkafka/serdes/avro/deserializers.py
@@ -1,6 +1,6 @@
 import io
 from json import loads
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from fastavro import parse_schema, schemaless_reader
 

--- a/wunderkafka/serdes/avro/deserializers.py
+++ b/wunderkafka/serdes/avro/deserializers.py
@@ -12,7 +12,7 @@ class FastAvroDeserializer(AbstractDeserializer):
     # ToDo (tribunsky.kir): it's better to cache loaded Schema earlier, but then it breaks layers.
 
     def __init__(self) -> None:
-        self._cache: Dict[str, FastAvroParsedSchema] = {}
+        self._cache: dict[str, FastAvroParsedSchema] = {}
 
     def deserialize(self, schema: str, blob: bytes, seek_pos: Optional[int] = None) -> Any:
         if schema not in self._cache:

--- a/wunderkafka/serdes/avro/serializers.py
+++ b/wunderkafka/serdes/avro/serializers.py
@@ -1,6 +1,6 @@
 import io
 from json import loads
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from fastavro import parse_schema, schemaless_writer
 

--- a/wunderkafka/serdes/avro/serializers.py
+++ b/wunderkafka/serdes/avro/serializers.py
@@ -10,7 +10,7 @@ from wunderkafka.serdes.avro.types import FastAvroParsedSchema
 
 class FastAvroSerializer(AbstractSerializer):
     def __init__(self, store: Optional[AbstractDescriptionStore] = None) -> None:
-        self._cache: Dict[str, FastAvroParsedSchema] = {}
+        self._cache: dict[str, FastAvroParsedSchema] = {}
         self.store = store
 
     def serialize(

--- a/wunderkafka/serdes/avro/types.py
+++ b/wunderkafka/serdes/avro/types.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union, Any
+from typing import Any, Union
 
 Field = dict[str, Union[str, list[str]]]
 # Just what we get from `from fastavro import parse_schema`

--- a/wunderkafka/serdes/avro/types.py
+++ b/wunderkafka/serdes/avro/types.py
@@ -1,5 +1,5 @@
 from typing import Dict, List, Union, Any
 
-Field = Dict[str, Union[str, List[str]]]
+Field = dict[str, Union[str, list[str]]]
 # Just what we get from `from fastavro import parse_schema`
-FastAvroParsedSchema = Union[str, List[Any], Dict[Any, Any]]
+FastAvroParsedSchema = Union[str, list[Any], dict[Any, Any]]

--- a/wunderkafka/serdes/avromodel/__init__.py
+++ b/wunderkafka/serdes/avromodel/__init__.py
@@ -1,1 +1,5 @@
 from wunderkafka.serdes.avromodel.derive.current import derive
+
+__all__ = [
+    'derive',
+]

--- a/wunderkafka/serdes/avromodel/derive/current.py
+++ b/wunderkafka/serdes/avromodel/derive/current.py
@@ -9,7 +9,7 @@ from wunderkafka.logger import logger
 from wunderkafka.serdes.avromodel.pydantic import derive_from_pydantic, exclude_pydantic_class
 
 
-def derive(model_type: Type[object], topic: str, *, is_key: bool = False) -> str:
+def derive(model_type: type[object], topic: str, *, is_key: bool = False) -> str:
     pydantic_model = derive_from_pydantic(model_type)
     if pydantic_model is None:
         if is_dataclass(model_type):
@@ -23,7 +23,7 @@ def derive(model_type: Type[object], topic: str, *, is_key: bool = False) -> str
             #   we avoid describing objects via nested types for HDFS's sake.
             attributes = _extract_attributes(model_type)
             ordering = list(attributes['__annotations__'])
-            crafted_model: Type[AvroModel] = type(model_type.__name__, (AvroModel,), attributes)
+            crafted_model: type[AvroModel] = type(model_type.__name__, (AvroModel,), attributes)
             model_schema = crafted_model.avro_schema_to_python()
             fields_map = {field_data['name']: field_data for field_data in model_schema['fields']}
             reordered_fields = [fields_map[attr] for attr in ordering]
@@ -35,7 +35,7 @@ def derive(model_type: Type[object], topic: str, *, is_key: bool = False) -> str
     if hasattr(model_type, 'Meta') and hasattr(model_type.Meta, 'name'):
         model_schema['name'] = model_type.Meta.name
     else:
-        model_schema['name'] = '{0}_{1}'.format(re.sub(r'[^\w_]', '_', topic), suffix)
+        model_schema['name'] = '{}_{}'.format(re.sub(r'[^\w_]', '_', topic), suffix)
     if model_schema['name'].startswith('_'):
         logger.warning('Topic name {0} starts with underscore, which is not allowed for Avro schema names.')
         model_schema['name'] = model_schema['name'][1:]
@@ -47,7 +47,7 @@ def derive(model_type: Type[object], topic: str, *, is_key: bool = False) -> str
     return json.dumps(model_schema)
 
 
-def _extract_attributes(type_: Type[object]) -> Dict[str, Any]:
+def _extract_attributes(type_: type[object]) -> dict[str, Any]:
     fields = vars(type_).get('__annotations__', {})
     _, *parents = type_.mro()
     for base in parents:

--- a/wunderkafka/serdes/avromodel/derive/current.py
+++ b/wunderkafka/serdes/avromodel/derive/current.py
@@ -1,6 +1,6 @@
-import json
 import re
-from typing import Any, Dict, Type
+import json
+from typing import Any
 from dataclasses import is_dataclass
 
 from dataclasses_avroschema import AvroModel

--- a/wunderkafka/serdes/avromodel/pydantic.py
+++ b/wunderkafka/serdes/avromodel/pydantic.py
@@ -1,10 +1,11 @@
-from typing import Final, FrozenSet, Type, Dict, Any, get_args, Union, Optional, TypeVar
+from typing import Any, Final, Union, TypeVar, Optional, get_args
 
 try:
     from dataclasses_avroschema.avrodantic import AvroBaseModel
 except ImportError:
     from dataclasses_avroschema.pydantic import AvroBaseModel
-from pydantic import BaseModel, create_model, ConfigDict
+
+from pydantic import BaseModel, ConfigDict, create_model
 from pydantic_settings import BaseSettings
 
 from wunderkafka.serdes.avromodel.typing import is_generic_type

--- a/wunderkafka/serdes/avromodel/serializers.py
+++ b/wunderkafka/serdes/avromodel/serializers.py
@@ -4,7 +4,7 @@ from dataclasses import asdict, is_dataclass
 from pydantic import BaseModel
 
 from wunderkafka.compat import ParamSpec
-from wunderkafka.serdes.abc import AbstractDescriptionStore, AbstractSerializer
+from wunderkafka.serdes.abc import AbstractSerializer, AbstractDescriptionStore
 from wunderkafka.serdes.avro import FastAvroSerializer
 
 P = ParamSpec('P')

--- a/wunderkafka/serdes/avromodel/typing/__init__.py
+++ b/wunderkafka/serdes/avromodel/typing/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type, get_origin, get_args
+from typing import Optional, get_args, get_origin
 
 
 def is_generic_type(annotation: Optional[type[object]]) -> bool:

--- a/wunderkafka/serdes/avromodel/typing/__init__.py
+++ b/wunderkafka/serdes/avromodel/typing/__init__.py
@@ -1,5 +1,5 @@
 from typing import Optional, Type, get_origin, get_args
 
 
-def is_generic_type(annotation: Optional[Type[object]]) -> bool:
+def is_generic_type(annotation: Optional[type[object]]) -> bool:
     return get_origin(annotation) is not None and len(get_args(annotation)) > 0

--- a/wunderkafka/serdes/avromodel/typing/compat.py
+++ b/wunderkafka/serdes/avromodel/typing/compat.py
@@ -1,8 +1,5 @@
 import inspect
-import sys
-import typing
-from types import MappingProxyType
-from typing import Any, List, Type, Union, get_origin
+from typing import Any, get_origin
 
 # We check it via import to avoid using nested imports in implementation in `is_union_type() function`
 HAS_UNION_TYPE = True

--- a/wunderkafka/serdes/avromodel/typing/compat.py
+++ b/wunderkafka/serdes/avromodel/typing/compat.py
@@ -11,13 +11,10 @@ try:
 except ImportError:
     HAS_UNION_TYPE = False
 
-if sys.version_info >= (3, 9):
-    from typing import Annotated
-else:
-    from typing_extensions import Annotated
+from typing import Annotated
 
 
-def create_annotation(generic: Any, types_list: List[Type[object]]) -> Type[object]:
+def create_annotation(generic: Any, types_list: list[type[object]]) -> type[object]:
     # return generic[Union[types_list]]
     return generic[tuple(types_list)]
 
@@ -30,22 +27,8 @@ else:
     def is_union_type(generic: Any) -> bool:
         return inspect.isclass(generic) and issubclass(generic, UnionType)
 
-if sys.version_info >= (3, 9):
-    def get_generic(annotation: Any) -> Any:
-        return get_origin(annotation)
+def get_generic(annotation: Any) -> Any:
+    return get_origin(annotation)
 
-    def is_annotated_type(annotation: Any) -> bool:
-        return get_origin(annotation) is Annotated
-else:
-    _TYPE_MAPPING = MappingProxyType({
-        getattr(t, '__origin__', None): t for t in typing.__dict__.values() if hasattr(t, '__origin__')
-    })
-
-    def get_generic(annotation: Any) -> Any:
-        origin = get_origin(annotation)
-        if origin is Union:
-            return Union
-        return _TYPE_MAPPING.get(origin)
-
-    def is_annotated_type(annotation: Any) -> bool:
-        return hasattr(annotation, '__metadata__') and hasattr(annotation, '__origin__')
+def is_annotated_type(annotation: Any) -> bool:
+    return get_origin(annotation) is Annotated

--- a/wunderkafka/serdes/avromodel/typing/compat.py
+++ b/wunderkafka/serdes/avromodel/typing/compat.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, get_origin
+from typing import Any, get_origin, Annotated
 
 # We check it via import to avoid using nested imports in implementation in `is_union_type() function`
 HAS_UNION_TYPE = True
@@ -7,8 +7,6 @@ try:
     from types import UnionType  # type: ignore[attr-defined]
 except ImportError:
     HAS_UNION_TYPE = False
-
-from typing import Annotated
 
 
 def create_annotation(generic: Any, types_list: list[type[object]]) -> type[object]:

--- a/wunderkafka/serdes/headers.py
+++ b/wunderkafka/serdes/headers.py
@@ -27,14 +27,14 @@ class ConfluentClouderaHeadersHandler(AbstractProtocolHandler):
 
     def parse(self, blob: bytes) -> ParsedHeader:
         if len(blob) < MIN_HEADER_SIZE:
-            raise DeserializerException("Message is too small to decode: ({!r})".format(blob))
+            raise DeserializerException(f"Message is too small to decode: ({blob!r})")
 
         # 1st byte is magic byte.
         [protocol_id] = struct.unpack('>b', blob[0:1])
 
         protocol = PROTOCOLS.get(protocol_id)
         if protocol is None:
-            raise DeserializerException('Unknown protocol extracted from message: {0}'.format(protocol_id))
+            raise DeserializerException(f'Unknown protocol extracted from message: {protocol_id}')
 
         # already read 1 byte from header as protocol id
         meta = struct.unpack(protocol.mask.unpack, blob[1:1+protocol.header_size])
@@ -58,11 +58,11 @@ class ConfluentClouderaHeadersHandler(AbstractProtocolHandler):
     def pack(self, protocol_id: int, meta: SRMeta) -> bytes:
         protocol = PROTOCOLS.get(protocol_id)
         if protocol is None:
-            raise ValueError('Unknown protocol_id {0}!'.format(protocol_id))
+            raise ValueError(f'Unknown protocol_id {protocol_id}!')
 
         if protocol_id == 1:
             if meta.meta_id is None:
-                err_msg = 'No meta id for protocol_id {0}. Please, check response from Schema Registry.'.format(
+                err_msg = 'No meta id for protocol_id {}. Please, check response from Schema Registry.'.format(
                     protocol_id)
                 raise ValueError(err_msg)
             return struct.pack(protocol.mask.pack, protocol_id, meta.meta_id, meta.schema_version)

--- a/wunderkafka/serdes/json/__init__.py
+++ b/wunderkafka/serdes/json/__init__.py
@@ -4,3 +4,8 @@ try:
     from confluent_kafka.schema_registry.json_schema import JSONDeserializer
 except ImportError:
     HAS_JSON_SCHEMA = False
+
+
+__all__ = [
+    'JSONDeserializer',
+]

--- a/wunderkafka/serdes/json/deserializers.py
+++ b/wunderkafka/serdes/json/deserializers.py
@@ -1,8 +1,9 @@
 import json
-from typing import Any, Dict, Optional
+from typing import Any, Optional
+
+from confluent_kafka.schema_registry.json_schema import JSONDeserializer as JSONDSchemaDeserializer
 
 from wunderkafka.serdes.abc import AbstractDeserializer
-from confluent_kafka.schema_registry.json_schema import JSONDeserializer as JSONDSchemaDeserializer
 
 
 class JSONDeserializer(AbstractDeserializer):

--- a/wunderkafka/serdes/json/deserializers.py
+++ b/wunderkafka/serdes/json/deserializers.py
@@ -8,7 +8,7 @@ from confluent_kafka.schema_registry.json_schema import JSONDeserializer as JSON
 class JSONDeserializer(AbstractDeserializer):
 
     def __init__(self) -> None:
-        self._cache: Dict[str, JSONDSchemaDeserializer] = {}
+        self._cache: dict[str, JSONDSchemaDeserializer] = {}
 
     def deserialize(self, schema: str, blob: bytes, seek_pos: Optional[int] = None) -> Any:
         if schema not in self._cache:

--- a/wunderkafka/serdes/json/serializers.py
+++ b/wunderkafka/serdes/json/serializers.py
@@ -6,10 +6,10 @@ from confluent_kafka.serialization import SerializationContext, MessageField
 
 from wunderkafka.serdes.abc import AbstractSerializer, AbstractDescriptionStore
 
-ConfluentAPI = Callable[[Any, SerializationContext], Dict]
+ConfluentAPI = Callable[[Any, SerializationContext], dict]
 
 
-def any_to_dict(obj: Any, _: SerializationContext) -> Dict:
+def any_to_dict(obj: Any, _: SerializationContext) -> dict:
     if isinstance(obj, dict):
         return obj
     return dict(obj)
@@ -22,7 +22,7 @@ class JSONSerializer(AbstractSerializer):
         store: Optional[AbstractDescriptionStore] = None,
         to_dict: ConfluentAPI = any_to_dict,
     ) -> None:
-        self._cache: Dict[str, JSONSchemaSerializer] = {}
+        self._cache: dict[str, JSONSchemaSerializer] = {}
         self._sr_client = schema_registry_client
         self._to_dict = to_dict
         self.store = store

--- a/wunderkafka/serdes/json/serializers.py
+++ b/wunderkafka/serdes/json/serializers.py
@@ -1,8 +1,8 @@
-from typing import Dict, Optional, Any, Callable
+from typing import Any, Callable, Optional
 
+from confluent_kafka.serialization import MessageField, SerializationContext
 from confluent_kafka.schema_registry import SchemaRegistryClient
 from confluent_kafka.schema_registry.json_schema import JSONSerializer as JSONSchemaSerializer
-from confluent_kafka.serialization import SerializationContext, MessageField
 
 from wunderkafka.serdes.abc import AbstractSerializer, AbstractDescriptionStore
 

--- a/wunderkafka/serdes/jsonmodel/__init__.py
+++ b/wunderkafka/serdes/jsonmodel/__init__.py
@@ -1,1 +1,5 @@
 from wunderkafka.serdes.jsonmodel.derive import derive
+
+__all__ = [
+    'derive',
+]

--- a/wunderkafka/serdes/jsonmodel/derive.py
+++ b/wunderkafka/serdes/jsonmodel/derive.py
@@ -30,5 +30,5 @@ class JSONClosedModelGenerator(GenerateJsonSchema):
         return json_schema
 
 
-def derive(model_type: Type[BaseModel], schema_generator: Type[GenerateJsonSchema]) -> str:
+def derive(model_type: type[BaseModel], schema_generator: type[GenerateJsonSchema]) -> str:
     return json.dumps(model_type.model_json_schema(schema_generator=schema_generator))

--- a/wunderkafka/serdes/jsonmodel/derive.py
+++ b/wunderkafka/serdes/jsonmodel/derive.py
@@ -1,9 +1,8 @@
 import json
-from typing import Type
 
 from pydantic import BaseModel
-from pydantic.json_schema import GenerateJsonSchema, DEFAULT_REF_TEMPLATE, JsonSchemaMode, JsonSchemaValue
 from pydantic_core import CoreSchema
+from pydantic.json_schema import DEFAULT_REF_TEMPLATE, JsonSchemaMode, JsonSchemaValue, GenerateJsonSchema
 
 
 class JSONClosedModelGenerator(GenerateJsonSchema):

--- a/wunderkafka/serdes/jsonmodel/serializers.py
+++ b/wunderkafka/serdes/jsonmodel/serializers.py
@@ -22,7 +22,7 @@ class JSONModelSerializer(AbstractSerializer):
         schema_registry_client: SchemaRegistryClient,
         store: Optional[AbstractDescriptionStore] = None,
     ) -> None:
-        self._cache: Dict[str, JSONSerializer] = {}
+        self._cache: dict[str, JSONSerializer] = {}
         self._sr_client = schema_registry_client
         self.store = store or JSONModelRepo()
 

--- a/wunderkafka/serdes/jsonmodel/serializers.py
+++ b/wunderkafka/serdes/jsonmodel/serializers.py
@@ -1,10 +1,10 @@
 import json
-from typing import Dict, Optional, Any
+from typing import Any, Optional
 
+from pydantic import BaseModel
+from confluent_kafka.serialization import MessageField, SerializationContext
 from confluent_kafka.schema_registry import SchemaRegistryClient
 from confluent_kafka.schema_registry.json_schema import JSONSerializer
-from confluent_kafka.serialization import SerializationContext, MessageField
-from pydantic import BaseModel
 
 from wunderkafka.serdes.abc import AbstractSerializer, AbstractDescriptionStore
 from wunderkafka.serdes.store import JSONModelRepo

--- a/wunderkafka/serdes/schemaless/json/deserializers.py
+++ b/wunderkafka/serdes/schemaless/json/deserializers.py
@@ -9,7 +9,7 @@ class SchemaLessJSONDeserializer(AbstractDeserializer):
 
     def __init__(self) -> None:
         self.schemaless = True
-        self._cache: Dict[str, JSONDSchemaDeserializer] = {}
+        self._cache: dict[str, JSONDSchemaDeserializer] = {}
 
     def deserialize(self, schema: str, blob: bytes, seek_pos: Optional[int] = None) -> Any:
         return json.loads(blob)

--- a/wunderkafka/serdes/schemaless/json/deserializers.py
+++ b/wunderkafka/serdes/schemaless/json/deserializers.py
@@ -1,8 +1,9 @@
 import json
-from typing import Any, Dict, Optional
+from typing import Any, Optional
+
+from confluent_kafka.schema_registry.json_schema import JSONDeserializer as JSONDSchemaDeserializer
 
 from wunderkafka.serdes.abc import AbstractDeserializer
-from confluent_kafka.schema_registry.json_schema import JSONDeserializer as JSONDSchemaDeserializer
 
 
 class SchemaLessJSONDeserializer(AbstractDeserializer):

--- a/wunderkafka/serdes/schemaless/json/serializers.py
+++ b/wunderkafka/serdes/schemaless/json/serializers.py
@@ -1,5 +1,4 @@
 import json
-
 from typing import Any, Optional
 
 from wunderkafka.serdes.abc import AbstractSerializer

--- a/wunderkafka/serdes/schemaless/jsonmodel/serializers.py
+++ b/wunderkafka/serdes/schemaless/jsonmodel/serializers.py
@@ -1,5 +1,3 @@
-import json
-
 from typing import Any, Optional
 
 from wunderkafka.serdes.abc import AbstractSerializer

--- a/wunderkafka/serdes/schemaless/string/deserializers.py
+++ b/wunderkafka/serdes/schemaless/string/deserializers.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 
-
 from confluent_kafka.serialization import StringDeserializer as _StringDeserializer
+
 from wunderkafka.serdes.abc import AbstractDeserializer
 
 

--- a/wunderkafka/serdes/store.py
+++ b/wunderkafka/serdes/store.py
@@ -58,7 +58,7 @@ class SchemaFSRepo(AbstractDescriptionStore):
 class AvroModelRepo(AbstractDescriptionStore):
 
     # ToDo (tribunsky.kir): change Type[AvroModel] to more general alias + check derivation from python built-ins
-    def add(self, topic: TopicName, value: Type[AvroModel], key: Optional[Type[AvroModel]]) -> None:
+    def add(self, topic: TopicName, value: type[AvroModel], key: Optional[type[AvroModel]]) -> None:
         self._values[topic] = ValueSchemaDescription(text=avromodel.derive(value, topic), type=SchemaType.AVRO)
         if key is not None:
             self._keys[topic] = KeySchemaDescription(
@@ -76,11 +76,11 @@ class JSONRepo(AbstractDescriptionStore):
 
 
 class JSONModelRepo(AbstractDescriptionStore):
-    def __init__(self, schema_generator: Type[GenerateJsonSchema] = JSONClosedModelGenerator) -> None:
+    def __init__(self, schema_generator: type[GenerateJsonSchema] = JSONClosedModelGenerator) -> None:
         super().__init__()
         self._schema_generator = schema_generator
 
-    def add(self, topic: TopicName, value: Type[BaseModel], key: Optional[Type[BaseModel]]) -> None:
+    def add(self, topic: TopicName, value: type[BaseModel], key: Optional[type[BaseModel]]) -> None:
         self._values[topic] = ValueSchemaDescription(
             text=jsonmodel.derive(value, self._schema_generator),
             type=SchemaType.JSON,

--- a/wunderkafka/serdes/store.py
+++ b/wunderkafka/serdes/store.py
@@ -1,16 +1,15 @@
-from typing import Type, Union, Optional
+from typing import Union, Optional
 from pathlib import Path
 
 from pydantic import BaseModel
 from pydantic.json_schema import GenerateJsonSchema
-
-from wunderkafka.serdes.jsonmodel.derive import JSONClosedModelGenerator
-from wunderkafka.structures import SchemaType
-from wunderkafka.types import TopicName, KeySchemaDescription, ValueSchemaDescription
-from wunderkafka.serdes.abc import AbstractDescriptionStore
 from dataclasses_avroschema import AvroModel
-from wunderkafka.serdes import avromodel
-from wunderkafka.serdes import jsonmodel
+
+from wunderkafka.types import TopicName, KeySchemaDescription, ValueSchemaDescription
+from wunderkafka.serdes import avromodel, jsonmodel
+from wunderkafka.serdes.abc import AbstractDescriptionStore
+from wunderkafka.structures import SchemaType
+from wunderkafka.serdes.jsonmodel.derive import JSONClosedModelGenerator
 
 
 class SchemaTextRepo(AbstractDescriptionStore):

--- a/wunderkafka/serdes/structures.py
+++ b/wunderkafka/serdes/structures.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
 
 
-class Mask(object):
+class Mask:
     def __init__(self, value: str):
         self._value = value
-        self.__unpack = '>{0}'.format(self._value)
-        self.__pack = '>b{0}'.format(self._value)
+        self.__unpack = f'>{self._value}'
+        self.__pack = f'>b{self._value}'
 
     @property
     def unpack(self) -> str:
@@ -17,6 +17,6 @@ class Mask(object):
 
 
 @dataclass(frozen=True)
-class Protocol(object):
+class Protocol:
     header_size: int
     mask: Mask

--- a/wunderkafka/structures.py
+++ b/wunderkafka/structures.py
@@ -15,21 +15,21 @@ class SchemaType(str, Enum):
 
 
 @dataclass(frozen=True)
-class Timestamp(object):
+class Timestamp:
     value: int
 
     def __str__(self) -> str:
-        return '{0}: {1:.2f} ({2})'.format(self.__class__.__name__, self.value, ts2dt(self.value))
+        return f'{self.__class__.__name__}: {self.value:.2f} ({ts2dt(self.value)})'
 
 
 @dataclass(frozen=True)
-class Offset(object):
+class Offset:
     value: int
 
 
 # ToDo (ka.tribunskii): compose header & meta in symmetrical way
 @dataclass(frozen=True)
-class ParsedHeader(object):
+class ParsedHeader:
     protocol_id: int
     meta_id: Optional[int]
     schema_id: Optional[int]
@@ -38,7 +38,7 @@ class ParsedHeader(object):
 
 
 @dataclass(frozen=True)
-class SchemaMeta(object):
+class SchemaMeta:
     topic: str
     is_key: bool
     header: ParsedHeader
@@ -57,12 +57,12 @@ class SchemaMeta(object):
         # Cloudera
         else:
             suffix = ':k' if self.is_key else ''
-        return '{0}{1}'.format(self.topic, suffix)
+        return f'{self.topic}{suffix}'
 
 
 # ToDo: (tribunsky.kir): add cross-validation of invariants on the model itself?
 @dataclass(frozen=True)
-class SRMeta(object):
+class SRMeta:
     """Meta, which is retrieved after schema registration."""
     # Confluent always has schema_id, but one of cloudera protocols doesn't use it
     schema_id: Optional[int]
@@ -73,7 +73,7 @@ class SRMeta(object):
 
 
 @dataclass(frozen=True)
-class SchemaDescription(object):
+class SchemaDescription:
     """
     Class to allow a contract extension between moving parts of (de)serialization.
 

--- a/wunderkafka/tests/__init__.py
+++ b/wunderkafka/tests/__init__.py
@@ -1,3 +1,10 @@
 from wunderkafka.tests.consumer import TestConsumer
 from wunderkafka.tests.producer import TestProducer
 from wunderkafka.tests.schema_registry import TestHTTPClient
+
+
+__all__ = [
+    'TestConsumer',
+    'TestProducer',
+    'TestHTTPClient',
+]

--- a/wunderkafka/tests/consumer.py
+++ b/wunderkafka/tests/consumer.py
@@ -7,7 +7,7 @@ from wunderkafka.consumers.bytes import BytesConsumer
 from wunderkafka.consumers.subscription import TopicSubscription
 
 
-class Message(object):
+class Message:
     def __init__(self, topic: str, value: bytes, key: Optional[bytes] = None, error: Optional[KafkaError] = None):
         self._topic = topic
         self._value = value
@@ -34,12 +34,12 @@ class Message(object):
 
 
 class TestConsumer(BytesConsumer):
-    def __init__(self, msgs: List[Message]) -> None:
+    def __init__(self, msgs: list[Message]) -> None:
         self._msgs = msgs
 
     def subscribe(
         self,
-        topics: List[Union[str, TopicSubscription]],
+        topics: list[Union[str, TopicSubscription]],
         *,
         from_beginning: Optional[bool] = None,
         offset: Optional[int] = None,
@@ -54,5 +54,5 @@ class TestConsumer(BytesConsumer):
         num_messages: int = 1000000,
         *,
         raise_on_lost: bool = False,
-    ) -> List[Message]:
+    ) -> list[Message]:
         return self._msgs

--- a/wunderkafka/tests/consumer.py
+++ b/wunderkafka/tests/consumer.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, List, Union, Optional
+from typing import Any, Union, Optional
 
 from confluent_kafka import KafkaError
 

--- a/wunderkafka/tests/producer.py
+++ b/wunderkafka/tests/producer.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Union, Optional
+from typing import Any, Union, Optional
 from dataclasses import dataclass
 
 from wunderkafka.types import DeliveryCallback

--- a/wunderkafka/tests/producer.py
+++ b/wunderkafka/tests/producer.py
@@ -7,7 +7,7 @@ from wunderkafka.producers.bytes import BytesProducer
 
 
 @dataclass
-class Message(object):
+class Message:
     topic: str
     value: Optional[Union[str, bytes]]
     key: Optional[Union[str, bytes]]
@@ -16,7 +16,7 @@ class Message(object):
 class TestProducer(BytesProducer):
 
     def __init__(self) -> None:
-        self.sent: List[Message] = []
+        self.sent: list[Message] = []
 
     def send_message(
         self,

--- a/wunderkafka/tests/schema_registry.py
+++ b/wunderkafka/tests/schema_registry.py
@@ -1,6 +1,6 @@
 import json
-from pathlib import Path
 from typing import Any, Union
+from pathlib import Path
 from urllib.parse import urlparse
 
 from wunderkafka.schema_registry.abc import AbstractHTTPClient

--- a/wunderkafka/tests/schema_registry.py
+++ b/wunderkafka/tests/schema_registry.py
@@ -14,9 +14,9 @@ class TestHTTPClient(AbstractHTTPClient):
     def make_request(self, relative_url: str, method: str = 'GET', body: Any = None, query: Any = None) -> Any:
         # ToDo (tribunsky.kir): rise up actual SR, stop using FS here.
         parsed = urlparse(relative_url)
-        filename = self._root / method / '{0}.json'.format(parsed.path)
+        filename = self._root / method / f'{parsed.path}.json'
         if parsed.path == 'schemas':
-            filename = self._root / method / relative_url / body['description'] / '{0}.json'.format(parsed.path)
+            filename = self._root / method / relative_url / body['description'] / f'{parsed.path}.json'
         with open(filename) as fl:
             return json.load(fl)
 

--- a/wunderkafka/time.py
+++ b/wunderkafka/time.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """Some timing boilerplate."""
 
 import time
@@ -30,4 +28,4 @@ def ts2dt(ts: float) -> datetime.datetime:
         return datetime.datetime.fromtimestamp(ts)
     if current_ts_len == ts_str_len_ms:
         return datetime.datetime.fromtimestamp(round(ts/1000))
-    raise ValueError('Invalid timestamp: {0} seems not to be a UNIX-timestamp in seconds or milliseconds'.format(ts))
+    raise ValueError(f'Invalid timestamp: {ts} seems not to be a UNIX-timestamp in seconds or milliseconds')

--- a/wunderkafka/types.py
+++ b/wunderkafka/types.py
@@ -1,7 +1,7 @@
 """This module contains aliases and helper definitions for type hints."""
 
 # ToDo (tribunsky.kir): move it to module with structures
-from typing import Any, Tuple, Union, Callable, Optional, Type
+from typing import Any, Union, Callable, Optional
 
 from confluent_kafka import Message, KafkaError
 

--- a/wunderkafka/types.py
+++ b/wunderkafka/types.py
@@ -19,7 +19,7 @@ MsgKey = Any
 KeySchemaDescription = SchemaDescription
 ValueSchemaDescription = SchemaDescription
 
-MessageDescription = Union[str, Tuple[str, str], Type, Tuple[Type, Type]]
+MessageDescription = Union[str, tuple[str, str], type, tuple[type, type]]
 TopicName = str
 
 HowToSubscribe = Optional[Union[Timestamp, Offset]]


### PR DESCRIPTION
I decided it would be nice to bump everything to up to date code style, so PR is a bit bigger, though still quite easy to go through. I fixed:

- annotations(List -> list etc.)
- outdated formating(like format method and % formatting)
- `class ClassName(object): ... -> class ClassName: ...`

I did not delete any tests as they target python 3.9, which does not support union annotations like `str | None`, so I left it for later updates.