### PR TITLE
Change release pipeline to be less messy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,10 @@
 name: release
 
 on:
-  push:
-    branches:
-      - master
-    tags:
-      - v*
+  workflow_dispatch: null
+  release:
+    types:
+      - published
 
 jobs:
   version:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,6 @@ ignore_token_for_push = false
 insecure = true
 [tool.semantic_release.publish]
 dist_glob_patterns = ["dist/*"]
-upload_to_vcs_release = true
 
 [tool.ruff]
 target-version="py39"


### PR DESCRIPTION
Our release pipeline is a bit clumsy. 

- do not upload test releases to vcs
- trigger release only when release is published. This will allow us to collect several fixes/features in main branch and release them all at once.

There is still a problem though. Our default branch is heavily protected, so no one can commit to this branch, including PSR. This problem has 2 solutions:

1. Ease our protection rules and give PSR an opportunity to make commits, when release pipeline is triggered
2. Remove PSR from release workflow entirely and bump version in pyproject manually before each release


I don't really know how to solve it now, but at least I don't want repo to be cluttered with beta releases.